### PR TITLE
fix: lerna-log での ログ出力時に MDC が消える問題を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `lerna-http`
     - Fixed an issue where HTTP Body was not logged
     - Fixed an issue where URL queries were not logged
+- `lerna-log`
+    - Fixed an issue where existing mdc was ignored when logging
+    - Fixed an issue where existing mdc was deleted after log output
 
 ### Added
 - `lerna-testkit`: Added testkit for TypedActor

--- a/build.sbt
+++ b/build.sbt
@@ -297,8 +297,9 @@ lazy val lernaLog = lernaModule("lerna-log")
       Dependencies.ScalaLang.scalaCollectionCompat,
       Dependencies.SLF4J.api,
       Dependencies.Akka.slf4j,
-      Dependencies.Akka.actorTyped % Optional,
-      Dependencies.Logback.classic % Optional,
+      Dependencies.Akka.actorTyped        % Optional,
+      Dependencies.Logback.classic        % Optional,
+      Dependencies.Akka.actorTestKitTyped % Test,
     ),
   )
 

--- a/lerna-log/src/test/scala/lerna/log/AppLoggingSpec.scala
+++ b/lerna-log/src/test/scala/lerna/log/AppLoggingSpec.scala
@@ -4,9 +4,12 @@ import akka.actor.testkit.typed.scaladsl.LoggingTestKit
 import akka.actor.typed.Behavior
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.{ Actor, Props }
+import akka.event.Logging
 import lerna.testkit.akka.ScalaTestWithTypedActorTestKit
 import lerna.tests.LernaBaseSpec
+import org.slf4j.MDC
 
+@SuppressWarnings(Array("org.wartremover.warts.Null"))
 final class AppLoggingSpec extends ScalaTestWithTypedActorTestKit() with LernaBaseSpec {
 
   "AppLogging.info should throw no exceptions when it takes standard types" in {
@@ -54,6 +57,24 @@ final class AppLoggingSpec extends ScalaTestWithTypedActorTestKit() with LernaBa
           LogTest.logger.info("dummy_log")
         }
     }
+
+    "既存の MDC を保持する" in {
+      implicit val logContext: LogContext = new LogContext {
+        override protected[log] def mdc: Map[String, String] = Map("logContext_mdc_key" -> "logContext_mdc_value")
+      }
+      LoggingTestKit
+        .custom { event =>
+          event.mdc.get("default_mdc_key") === Option("default_mdc_value") &&
+          event.mdc.get("logContext_mdc_key") === Option("logContext_mdc_value")
+        }
+        .expect {
+          MDC.put("default_mdc_key", "default_mdc_value")
+          LogTest.logger.info("dummy_log")
+        }
+
+      expect(MDC.get("default_mdc_key") === "default_mdc_value")
+      expect(MDC.get("logContext_mdc_key") === null)
+    }
   }
 
   "AppActorLogging" should {
@@ -77,6 +98,44 @@ final class AppLoggingSpec extends ScalaTestWithTypedActorTestKit() with LernaBa
           })
         }
     }
+
+    "override def mdc でセットされたMDCを保持する" in {
+      implicit val logContext: LogContext = new LogContext {
+        override protected[log] def mdc: Map[String, String] = Map("logContext_mdc_key" -> "logContext_mdc_value")
+      }
+      val probe = createTestProbe[Logging.MDC]()
+
+      LoggingTestKit
+        .custom { event =>
+          event.mdc.get("static_mdc_key") === Option("static_mdc_value") &&
+          event.mdc.get("received_message_key") === Option("dummy_message") &&
+          event.mdc.get("logContext_mdc_key") === Option("logContext_mdc_value")
+        }
+        .expect {
+          spawn(Behaviors.setup[Unit] { context => // typed ActorSystem から classic Actor を直接作れないため typed Actor で wrap
+            import akka.actor.typed.scaladsl.adapter._
+            val actor = context.actorOf(Props(new Actor with AppActorLogging {
+              override def mdc(currentMessage: Any): Logging.MDC = {
+                val staticMdc  = Map("static_mdc_key" -> "static_mdc_value")
+                val perMessage = Map("received_message_key" -> currentMessage.toString)
+                staticMdc ++ perMessage
+              }
+              override def receive: Receive = {
+                case _ =>
+                  logger.info("dummy_log")
+                  probe.ref ! log.mdc
+              }
+            }))
+            actor ! "dummy_message"
+            Behaviors.empty
+          })
+        }
+
+      val mdc = probe.receiveMessage()
+      expect(mdc.get("static_mdc_key") === Option("static_mdc_value"))
+      expect(mdc.get("received_message_key") === Option("dummy_message"))
+      expect(mdc.get("logContext_mdc_key") === None)
+    }
   }
 
   "AppTypedActorLogging" should {
@@ -97,6 +156,37 @@ final class AppLoggingSpec extends ScalaTestWithTypedActorTestKit() with LernaBa
         }
         .expect {
           spawn(LogTestActor())
+        }
+    }
+
+    "Behaviors.withMdc でセットされたMDCを保持する" in {
+      implicit val logContext: LogContext = new LogContext {
+        override protected[log] def mdc: Map[String, String] = Map("logContext_mdc_key" -> "logContext_mdc_value")
+      }
+      object LogTestActor extends AppTypedActorLogging {
+        private val staticMdc = Map("static_mdc_key" -> "static_mdc_value")
+
+        def apply(): Behavior[String] = Behaviors.withMdc(
+          staticMdc,
+          mdcForMessage = (msg: String) => Map("received_message_key" -> msg),
+        ) {
+          withLogger { logger =>
+            Behaviors.receiveMessage { _ =>
+              logger.info("dummy_log")
+              Behaviors.stopped
+            }
+          }
+        }
+      }
+      LoggingTestKit
+        .custom { event =>
+          event.mdc.get("static_mdc_key") === Option("static_mdc_value") &&
+          event.mdc.get("received_message_key") === Option("dummy_message") &&
+          event.mdc.get("logContext_mdc_key") === Option("logContext_mdc_value")
+        }
+        .expect {
+          val actor = spawn(LogTestActor())
+          actor ! "dummy_message"
         }
     }
   }


### PR DESCRIPTION
## 問題
元々MDCに値がsetされている場合、ログ出力時・出力後に失われる

## TODO
- [x] test
- [x] CHANGELOG.md を作る