### PR TITLE
Typed/lerna util akka

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `lerna-testkit`: Added testkit for TypedActor
 - `lerna-log`: Added Logger for TypedActor
+- `lerna-util-akka`: Added `AtLeastOnceDelivery` API for TypedActor 
 
 ### Changed
 - `lerna-management`

--- a/build.sbt
+++ b/build.sbt
@@ -331,8 +331,10 @@ lazy val lernaUtilAkka = lernaModule("lerna-util-akka")
   .settings(
     libraryDependencies ++= Seq(
       Dependencies.Akka.actor,
+      Dependencies.Akka.actorTyped,
       Dependencies.Akka.stream,
       Dependencies.Akka.testKit              % Test,
+      Dependencies.Akka.actorTestKitTyped    % Test,
       Dependencies.Akka.streamTestKit        % Test,
       Dependencies.Akka.serializationJackson % Test,
     ),

--- a/lerna-util-akka/src/main/mima-filters/1.0.0.backwards.excludes/7-AtLeastOnceDelivery-for-typed.backwards.excludes
+++ b/lerna-util-akka/src/main/mima-filters/1.0.0.backwards.excludes/7-AtLeastOnceDelivery-for-typed.backwards.excludes
@@ -1,0 +1,2 @@
+# シリアライズ互換性は protobuf を使用している・元々 package private なので問題なし
+ProblemFilters.exclude[MissingClassProblem]("lerna.util.akka.AtLeastOnceDelivery$AtLeastOnceDeliveryConfirm$")

--- a/lerna-util-akka/src/main/scala/lerna/util/akka/AtLeastOnceDelivery.scala
+++ b/lerna-util-akka/src/main/scala/lerna/util/akka/AtLeastOnceDelivery.scala
@@ -32,7 +32,6 @@ object AtLeastOnceDelivery {
     * @param system The [[akka.actor.ActorSystem]] to be used
     * @param timeout The entire timeout
     * @return The [[scala.concurrent.Future]] holding the reply message or an exception
-    * @note Use [[https://doc.akka.io/docs/akka/current/typed/reliable-delivery.html Akka Reliable Delivery]] if you use Akka typed.
     */
   def askTo(
       destination: ActorRef,

--- a/lerna-util-akka/src/main/scala/lerna/util/akka/AtLeastOnceDelivery.scala
+++ b/lerna-util-akka/src/main/scala/lerna/util/akka/AtLeastOnceDelivery.scala
@@ -1,7 +1,7 @@
 package lerna.util.akka
 
-import akka.actor.{ Actor, ActorRef, ActorSystem, Cancellable, NoSerializationVerificationNeeded, Props }
-import akka.pattern.ask
+import akka.actor.typed.scaladsl.adapter._
+import akka.actor.{ typed, Actor, ActorRef, ActorSystem, Cancellable, NoSerializationVerificationNeeded, Props }
 import akka.util.Timeout
 import lerna.log.AppActorLogging
 import lerna.util.time.JavaDurationConverters._
@@ -38,6 +38,7 @@ object AtLeastOnceDelivery {
       destination: ActorRef,
       message: Any,
   )(implicit requestContext: RequestContext, system: ActorSystem, timeout: Timeout): Future[Any] = {
+    import akka.pattern.ask
     val atLeastOnceDeliveryProxy = system.actorOf(AtLeastOnceDelivery.props(destination))
     atLeastOnceDeliveryProxy ? AtLeastOnceDeliveryRequest(message)(atLeastOnceDeliveryProxy)
   }
@@ -69,12 +70,62 @@ object AtLeastOnceDelivery {
     atLeastOnceDeliveryProxy ! AtLeastOnceDeliveryRequest(message)(atLeastOnceDeliveryProxy)
   }
 
+  /** Send the message asynchronously and return a [[scala.concurrent.Future]] holding the reply message.
+    * If no message is received within `timeout`, the [[scala.concurrent.Future]] holding an [[akka.pattern.AskTimeoutException]] is returned.
+    * This behavior is the same as Akka's ask pattern, but this method has some different behavior like below.
+    *
+    * The sender waits for a reply message of the sent message until a specific timeout (called `redeliver-interval`) is reached.
+    * If the sender receives no reply, the sender retries to send the same message again.
+    * This retransmission continues until another specific timeout (called `retry-timeout`) is reached.
+    * The above timeouts can be configured in your configuration file such as `reference.conf`.
+    * @param destination The destination typed actor to send
+    * @param message The message factory
+    * @param requestContext The context to be used for logging
+    * @param system The [[akka.actor.typed.ActorSystem]] to be used
+    * @param timeout The entire timeout
+    * @tparam Command Type of message to send
+    * @tparam Reply The type of reply message
+    * @return The [[scala.concurrent.Future]] holding the reply message or an exception
+    */
+  def askTo[Command, Reply](
+      destination: typed.ActorRef[Command],
+      message: (typed.ActorRef[Reply], typed.ActorRef[AtLeastOnceDeliveryConfirm.type]) => Command,
+  )(implicit requestContext: RequestContext, system: typed.ActorSystem[_], timeout: Timeout): Future[Reply] = {
+    import akka.actor.typed.scaladsl.AskPattern._
+    val atLeastOnceDeliveryProxy = system.toClassic.actorOf(AtLeastOnceDelivery.props(destination.toClassic)).toTyped
+    atLeastOnceDeliveryProxy.ask[Reply](replyTo => message(replyTo, atLeastOnceDeliveryProxy))
+  }
+
+  /** Send the message and return nothing.
+    * This method has some different behavior from Akka's tell pattern, like below.
+    *
+    * In this method, the sender actor is created, and it waits for a reply message.
+    * If the sender receives no reply, the sender retries tto send the same message gain.
+    * This retransmission continues until a specific timeout (called `retry-timeout`) is reached.
+    * The timeouts related to this method can be configured in your configuration file such as `reference.conf`.
+    *
+    * ==CAUTIONS==
+    * If you use this method, you should be careful about the below.
+    * We cannot know whether the receiver actually got the message.
+    * Moreover, we have no chance to know whether the sender continues sending the message or not.
+    * @param destination The destination typed actor to send
+    * @param message The message factory
+    * @param requestContext The context to be used for logging
+    * @param system The [[akka.actor.typed.ActorSystem]] to be used
+    * @tparam Command Type of message to send
+    */
+  def tellTo[Command](
+      destination: typed.ActorRef[Command],
+      message: typed.ActorRef[AtLeastOnceDeliveryConfirm.type] => Command,
+  )(implicit requestContext: RequestContext, system: typed.ActorSystem[_]): Unit = {
+    val atLeastOnceDeliveryProxy = system.toClassic.actorOf(AtLeastOnceDelivery.props(destination.toClassic))
+    atLeastOnceDeliveryProxy ! message(atLeastOnceDeliveryProxy)
+  }
+
   // Actor's protocol
   private[akka] sealed trait AtLeastOnceDeliveryCommand
 
-  private[akka] case object AtLeastOnceDeliveryConfirm
-      extends AtLeastOnceDeliveryCommand
-      with AtLeastOnceDeliverySerializable
+  case object AtLeastOnceDeliveryConfirm extends AtLeastOnceDeliveryCommand with AtLeastOnceDeliverySerializable
 
   /** A message that holds the original message and the destination actor to send a confirmation
     *

--- a/lerna-util-akka/src/main/scala/lerna/util/akka/AtLeastOnceDelivery.scala
+++ b/lerna-util-akka/src/main/scala/lerna/util/akka/AtLeastOnceDelivery.scala
@@ -39,7 +39,7 @@ object AtLeastOnceDelivery {
       message: Any,
   )(implicit requestContext: RequestContext, system: ActorSystem, timeout: Timeout): Future[Any] = {
     val atLeastOnceDeliveryProxy = system.actorOf(AtLeastOnceDelivery.props(destination))
-    atLeastOnceDeliveryProxy ? message
+    atLeastOnceDeliveryProxy ? AtLeastOnceDeliveryRequest(message)(atLeastOnceDeliveryProxy)
   }
 
   /** Send the message and return nothing.
@@ -66,7 +66,7 @@ object AtLeastOnceDelivery {
       message: Any,
   )(implicit requestContext: RequestContext, system: ActorSystem, sender: ActorRef = Actor.noSender): Unit = {
     val atLeastOnceDeliveryProxy = system.actorOf(AtLeastOnceDelivery.props(destination))
-    atLeastOnceDeliveryProxy ! message
+    atLeastOnceDeliveryProxy ! AtLeastOnceDeliveryRequest(message)(atLeastOnceDeliveryProxy)
   }
 
   // Actor's protocol
@@ -146,7 +146,7 @@ private[akka] final class AtLeastOnceDelivery(destination: ActorRef)(implicit re
       self ! SendRequest
 
     case SendRequest =>
-      destination.tell(AtLeastOnceDeliveryRequest(message), replyTo.actorRef)
+      destination.tell(message, replyTo.actorRef)
 
     case AtLeastOnceDeliveryConfirm =>
       context.stop(self)

--- a/lerna-util-akka/src/main/scala/lerna/util/akka/AtLeastOnceDelivery.scala
+++ b/lerna-util-akka/src/main/scala/lerna/util/akka/AtLeastOnceDelivery.scala
@@ -89,7 +89,7 @@ object AtLeastOnceDelivery {
     */
   def askTo[Command, Reply](
       destination: typed.ActorRef[Command],
-      message: (typed.ActorRef[Reply], typed.ActorRef[Confirm.type]) => Command,
+      message: (typed.ActorRef[Reply], typed.ActorRef[Confirm]) => Command,
   )(implicit requestContext: RequestContext, system: typed.ActorSystem[_], timeout: Timeout): Future[Reply] = {
     import akka.actor.typed.scaladsl.AskPattern._
     val atLeastOnceDeliveryProxy = system.toClassic.actorOf(AtLeastOnceDelivery.props(destination.toClassic)).toTyped
@@ -116,7 +116,7 @@ object AtLeastOnceDelivery {
     */
   def tellTo[Command](
       destination: typed.ActorRef[Command],
-      message: typed.ActorRef[Confirm.type] => Command,
+      message: typed.ActorRef[Confirm] => Command,
   )(implicit requestContext: RequestContext, system: typed.ActorSystem[_]): Unit = {
     val atLeastOnceDeliveryProxy = system.toClassic.actorOf(AtLeastOnceDelivery.props(destination.toClassic))
     atLeastOnceDeliveryProxy ! message(atLeastOnceDeliveryProxy)
@@ -125,7 +125,8 @@ object AtLeastOnceDelivery {
   // Actor's protocol
   private[akka] sealed trait AtLeastOnceDeliveryCommand
 
-  case object Confirm extends AtLeastOnceDeliveryCommand with AtLeastOnceDeliverySerializable
+  sealed trait Confirm extends AtLeastOnceDeliveryCommand
+  case object Confirm  extends Confirm with AtLeastOnceDeliverySerializable
 
   /** A message that holds the original message and the destination actor to send a confirmation
     *

--- a/lerna-util-akka/src/main/scala/lerna/util/akka/protobuf/AtLeastOnceDeliverySerializer.scala
+++ b/lerna-util-akka/src/main/scala/lerna/util/akka/protobuf/AtLeastOnceDeliverySerializer.scala
@@ -66,12 +66,12 @@ private[akka] final class AtLeastOnceDeliverySerializer(val system: ExtendedActo
 
   private def serializableToManifest(message: AtLeastOnceDeliverySerializable): String = message match {
     case _: AtLeastOnceDeliveryRequest => RequestManifest
-    case AtLeastOnceDeliveryConfirm    => ConfirmManifest
+    case Confirm                       => ConfirmManifest
   }
 
   private def serializableToBinary(message: AtLeastOnceDeliverySerializable): Array[Byte] = message match {
-    case m: AtLeastOnceDeliveryRequest      => requestToBinary(m)
-    case m: AtLeastOnceDeliveryConfirm.type => confirmToBinary(m)
+    case m: AtLeastOnceDeliveryRequest => requestToBinary(m)
+    case m: Confirm.type               => confirmToBinary(m)
   }
 
   private def requestToBinary(request: AtLeastOnceDeliveryRequest): Array[Byte] = {
@@ -96,15 +96,15 @@ private[akka] final class AtLeastOnceDeliverySerializer(val system: ExtendedActo
     AtLeastOnceDeliveryRequest(originalMessage)(replyActorRef)
   }
 
-  private def confirmToBinary(message: AtLeastOnceDeliveryConfirm.type): Array[Byte] = {
+  private def confirmToBinary(message: Confirm.type): Array[Byte] = {
     // We serialize nothing for now, but use protobuf for schema evolution in the future.
     msg.AtLeastOnceDeliveryConfirm.of().toByteArray
   }
 
-  private def confirmFromBinary(bytes: Array[Byte]): AtLeastOnceDeliveryConfirm.type = {
+  private def confirmFromBinary(bytes: Array[Byte]): Confirm.type = {
     // We don't need anything from deserialized message, but check it for safety guard.
     val _ = msg.AtLeastOnceDeliveryConfirm.parseFrom(bytes)
-    AtLeastOnceDeliveryConfirm
+    Confirm
   }
 
   private def payloadToProto(message: Any): msg.Payload = {

--- a/lerna-util-akka/src/test/scala/lerna/util/akka/AtLeastOnceDeliverySpec.scala
+++ b/lerna-util-akka/src/test/scala/lerna/util/akka/AtLeastOnceDeliverySpec.scala
@@ -211,7 +211,7 @@ object AtLeastOnceDeliveryTypedSpec {
   final case class RequestMessage(
       message: String,
       replyTo: ActorRef[ResponseMessage],
-      confirmTo: ActorRef[AtLeastOnceDelivery.AtLeastOnceDeliveryConfirm.type],
+      confirmTo: ActorRef[AtLeastOnceDelivery.Confirm.type],
   )
   final case class ResponseMessage(message: String)
 }
@@ -239,7 +239,7 @@ class AtLeastOnceDeliveryTypedSpec
         val request = destinationProbe.receiveMessage()
         expect(request.message === requestMessage)
 
-        request.confirmTo ! AtLeastOnceDelivery.AtLeastOnceDeliveryConfirm
+        request.confirmTo ! AtLeastOnceDelivery.Confirm
         request.replyTo ! responseMessage
       }
 
@@ -268,7 +268,7 @@ class AtLeastOnceDeliveryTypedSpec
         val request4 = destinationProbe.receiveMessage()
         expect(request4.message === requestMessage)
 
-        request4.confirmTo ! AtLeastOnceDelivery.AtLeastOnceDeliveryConfirm
+        request4.confirmTo ! AtLeastOnceDelivery.Confirm
         destinationProbe.expectNoMessage()
       }
     }
@@ -310,7 +310,7 @@ class AtLeastOnceDeliveryTypedSpec
         val request = destinationProbe.receiveMessage()
         expect(request.message === requestMessage)
 
-        request.confirmTo ! AtLeastOnceDelivery.AtLeastOnceDeliveryConfirm
+        request.confirmTo ! AtLeastOnceDelivery.Confirm
         request.replyTo ! responseMessage
       }
 
@@ -339,7 +339,7 @@ class AtLeastOnceDeliveryTypedSpec
         val request4 = destinationProbe.receiveMessage()
         expect(request4.message === requestMessage)
 
-        request4.confirmTo ! AtLeastOnceDelivery.AtLeastOnceDeliveryConfirm
+        request4.confirmTo ! AtLeastOnceDelivery.Confirm
         destinationProbe.expectNoMessage()
         replyToProbe.expectNoMessage()
       }

--- a/lerna-util-akka/src/test/scala/lerna/util/akka/AtLeastOnceDeliverySpec.scala
+++ b/lerna-util-akka/src/test/scala/lerna/util/akka/AtLeastOnceDeliverySpec.scala
@@ -211,7 +211,7 @@ object AtLeastOnceDeliveryTypedSpec {
   final case class RequestMessage(
       message: String,
       replyTo: ActorRef[ResponseMessage],
-      confirmTo: ActorRef[AtLeastOnceDelivery.Confirm.type],
+      confirmTo: ActorRef[AtLeastOnceDelivery.Confirm],
   )
   final case class ResponseMessage(message: String)
 }

--- a/lerna-util-akka/src/test/scala/lerna/util/akka/AtLeastOnceDeliverySpec.scala
+++ b/lerna-util-akka/src/test/scala/lerna/util/akka/AtLeastOnceDeliverySpec.scala
@@ -3,9 +3,13 @@ package lerna.util.akka
 import java.util.concurrent.atomic.AtomicInteger
 
 import akka.actor.ActorSystem
+import akka.actor.testkit.typed.scaladsl.FishingOutcomes
+import akka.actor.typed.ActorRef
 import akka.testkit.TestProbe
 import akka.util.Timeout
 import com.typesafe.config.{ Config, ConfigFactory }
+import lerna.testkit.akka.ScalaTestWithTypedActorTestKit
+import lerna.tests.LernaBaseSpec
 import lerna.util.akka.AtLeastOnceDelivery.AtLeastOnceDeliveryRequest
 import lerna.util.trace.TraceId
 
@@ -171,6 +175,192 @@ class AtLeastOnceDeliverySpec
           case request: AtLeastOnceDeliveryRequest =>
             expect(request.originalMessage === requestMessage)
         }
+
+        destinationProbe.expectNoMessage()
+      }
+    }
+  }
+
+  private val generateUniqueNumber: () => Int = {
+    val counter = new AtomicInteger()
+    () => counter.getAndIncrement()
+  }
+}
+
+object AtLeastOnceDeliveryTypedSpec {
+  private val redeliverInterval = 100.milliseconds
+  private val retryTimeout      = 1000.milliseconds
+
+  private val config: Config = ConfigFactory
+    .parseString(s"""
+                    | akka.actor {
+                    |   provider = local
+                    |   serialize-messages = on
+                    |   serialization-bindings {
+                    |     "lerna.util.akka.AtLeastOnceDeliveryTypedSpec$$RequestMessage" = jackson-json
+                    |     "lerna.util.akka.AtLeastOnceDeliveryTypedSpec$$ResponseMessage" = jackson-json
+                    |   }
+                    | }
+                    | lerna.util.akka.at-least-once-delivery {
+                    |   redeliver-interval = ${redeliverInterval.toMillis.toString} ms
+                    |   retry-timeout = ${retryTimeout.toMillis.toString} ms
+                    | }
+       """.stripMargin)
+    .withFallback(ConfigFactory.load())
+
+  final case class RequestMessage(
+      message: String,
+      replyTo: ActorRef[ResponseMessage],
+      confirmTo: ActorRef[AtLeastOnceDelivery.AtLeastOnceDeliveryConfirm.type],
+  )
+  final case class ResponseMessage(message: String)
+}
+
+class AtLeastOnceDeliveryTypedSpec
+    extends ScalaTestWithTypedActorTestKit(AtLeastOnceDeliveryTypedSpec.config)
+    with LernaBaseSpec {
+
+  import AtLeastOnceDeliveryTypedSpec._
+
+  implicit val askTimeout: Timeout = 5.seconds
+  implicit val traceId: TraceId    = TraceId.unknown
+
+  "askTo()" should {
+    "宛先に到達保証用メッセージを送信できる" in {
+      val destinationProbe = testKit.createTestProbe[RequestMessage]()
+
+      val requestMessage  = s"request-${generateUniqueNumber().toString}"
+      val responseMessage = ResponseMessage(s"response-${generateUniqueNumber().toString}")
+
+      val resultFuture = AtLeastOnceDelivery.askTo(destinationProbe.ref, RequestMessage(requestMessage, _, _))
+
+      {
+        // destination側
+        val request = destinationProbe.receiveMessage()
+        expect(request.message === requestMessage)
+
+        request.confirmTo ! AtLeastOnceDelivery.AtLeastOnceDeliveryConfirm
+        request.replyTo ! responseMessage
+      }
+
+      whenReady(resultFuture) { result =>
+        expect(result === responseMessage)
+      }
+    }
+
+    "confirm されない場合は再送する" in {
+      val destinationProbe = testKit.createTestProbe[RequestMessage]()
+      val requestMessage   = s"request-${generateUniqueNumber().toString}"
+
+      AtLeastOnceDelivery.askTo(destinationProbe.ref, RequestMessage(requestMessage, _, _))
+
+      {
+        // destination側
+        val request1 = destinationProbe.receiveMessage()
+        expect(request1.message === requestMessage)
+
+        val request2 = destinationProbe.receiveMessage()
+        expect(request2.message === requestMessage)
+
+        val request3 = destinationProbe.receiveMessage()
+        expect(request3.message === requestMessage)
+
+        val request4 = destinationProbe.receiveMessage()
+        expect(request4.message === requestMessage)
+
+        request4.confirmTo ! AtLeastOnceDelivery.AtLeastOnceDeliveryConfirm
+        destinationProbe.expectNoMessage()
+      }
+    }
+
+    "retry-timeout時間経過しても confirm されなかった場合再送を中止する" in {
+      val destinationProbe = testKit.createTestProbe[RequestMessage]()
+
+      val requestMessage = s"request-${generateUniqueNumber().toString}"
+
+      AtLeastOnceDelivery.askTo(destinationProbe.ref, RequestMessage(requestMessage, _, _))
+
+      {
+        // destination側
+        val assertionError = intercept[AssertionError] { // wait for a timeout
+          destinationProbe.fishForMessage(max = retryTimeout * 2) {
+            case request if request.message === requestMessage => FishingOutcomes.continueAndIgnore
+            case _                                             => FishingOutcomes.fail("unexpected message")
+          }
+        }
+        expect(assertionError.getMessage.startsWith("timeout"))
+
+        destinationProbe.expectNoMessage()
+      }
+    }
+  }
+
+  "tellTo()" should {
+    "宛先に到達保証用メッセージを送信できる" in {
+      val destinationProbe = testKit.createTestProbe[RequestMessage]()
+      val replyToProbe     = testKit.createTestProbe[ResponseMessage]()
+
+      val requestMessage  = s"request-${generateUniqueNumber().toString}"
+      val responseMessage = ResponseMessage(s"response-${generateUniqueNumber().toString}")
+
+      AtLeastOnceDelivery.tellTo(destinationProbe.ref, RequestMessage(requestMessage, replyToProbe.ref, _))
+
+      {
+        // destination側
+        val request = destinationProbe.receiveMessage()
+        expect(request.message === requestMessage)
+
+        request.confirmTo ! AtLeastOnceDelivery.AtLeastOnceDeliveryConfirm
+        request.replyTo ! responseMessage
+      }
+
+      replyToProbe.expectMessage(responseMessage)
+    }
+
+    "confirm されない場合は再送する" in {
+      val destinationProbe = testKit.createTestProbe[RequestMessage]()
+      val replyToProbe     = testKit.createTestProbe[ResponseMessage]()
+
+      val requestMessage = s"request-${generateUniqueNumber().toString}"
+
+      AtLeastOnceDelivery.tellTo(destinationProbe.ref, RequestMessage(requestMessage, replyToProbe.ref, _))
+
+      {
+        // destination側
+        val request1 = destinationProbe.receiveMessage()
+        expect(request1.message === requestMessage)
+
+        val request2 = destinationProbe.receiveMessage()
+        expect(request2.message === requestMessage)
+
+        val request3 = destinationProbe.receiveMessage()
+        expect(request3.message === requestMessage)
+
+        val request4 = destinationProbe.receiveMessage()
+        expect(request4.message === requestMessage)
+
+        request4.confirmTo ! AtLeastOnceDelivery.AtLeastOnceDeliveryConfirm
+        destinationProbe.expectNoMessage()
+        replyToProbe.expectNoMessage()
+      }
+    }
+
+    "retry-timeout時間経過しても confirm されなかった場合再送を中止する" in {
+      val destinationProbe = testKit.createTestProbe[RequestMessage]()
+
+      val requestMessage = s"request-${generateUniqueNumber().toString}"
+
+      AtLeastOnceDelivery.askTo(destinationProbe.ref, RequestMessage(requestMessage, _, _))
+
+      {
+        // destination側
+        val assertionError = intercept[AssertionError] { // wait for a timeout
+          destinationProbe.fishForMessage(max = retryTimeout * 2) {
+            case request if request.message === requestMessage => FishingOutcomes.continueAndIgnore
+            case _                                             => FishingOutcomes.fail("unexpected message")
+          }
+        }
+        expect(assertionError.getMessage.startsWith("timeout"))
 
         destinationProbe.expectNoMessage()
       }

--- a/lerna-util-akka/src/test/scala/lerna/util/akka/protobuf/AtLeastOnceDeliverySerializerBindingSpec.scala
+++ b/lerna-util-akka/src/test/scala/lerna/util/akka/protobuf/AtLeastOnceDeliverySerializerBindingSpec.scala
@@ -22,7 +22,7 @@ final class AtLeastOnceDeliverySerializerBindingSpec
       val ref = system.actorOf(TestActors.blackholeProps)
       checkSerializer(AtLeastOnceDeliveryRequest(123)(ref))
       checkSerializer(AtLeastOnceDeliveryRequest("abc")(ref))
-      checkSerializer(AtLeastOnceDeliveryConfirm)
+      checkSerializer(Confirm)
     }
   }
 

--- a/lerna-util-akka/src/test/scala/lerna/util/akka/protobuf/AtLeastOnceDeliverySerializerSpec.scala
+++ b/lerna-util-akka/src/test/scala/lerna/util/akka/protobuf/AtLeastOnceDeliverySerializerSpec.scala
@@ -24,7 +24,7 @@ final class AtLeastOnceDeliverySerializerSpec()
       val ref = system.actorOf(TestActors.blackholeProps)
       checkSerialization(AtLeastOnceDeliveryRequest(123)(ref))
       checkSerialization(AtLeastOnceDeliveryRequest("abcdef")(ref))
-      checkSerialization(AtLeastOnceDeliveryConfirm)
+      checkSerialization(Confirm)
     }
 
   }
@@ -49,7 +49,7 @@ final class AtLeastOnceDeliverySerializerSpec()
 
   "AtLeastOnceDeliverySerializer.fromBinary" should {
     "throw a NotSerializableException if the given manifest is invalid" in {
-      val validBinary     = serializer.toBinary(AtLeastOnceDeliveryConfirm)
+      val validBinary     = serializer.toBinary(Confirm)
       val invalidManifest = "INVALID_MANIFEST"
       a[NotSerializableException] shouldBe thrownBy {
         serializer.fromBinary(validBinary, invalidManifest)


### PR DESCRIPTION
## 対象
- [x] `lerna-util-akka/src/main/scala/lerna/util/akka/AtLeastOnceDelivery.scala`
- [ ] ~`lerna-util-akka/src/main/scala/lerna/util/akka/ProcessingTimeout.scala`~ 変更不要
  - typed で使う場合は、Command trait を 継承している必要があるため、 wrap して使う

## TODO
- [x] 実装
- [x] test
- [x] ドキュメント
  - [x] Scala doc
  - [x] `doc/lerna-util-akka.md`
  - [x] `CHANGELOG.md`

## 使い方の例 (lerna-sample-payment-app)
https://github.com/lerna-stack/lerna-sample-payment-app/pull/22

- AtLeastOnceDelivery
  - 送信側: [lerna-sample-payment-app/IssuingServiceECPaymentApplicationImpl.scala at feature/akka-typed · lerna-stack/lerna-sample-payment-app](https://github.com/lerna-stack/lerna-sample-payment-app/blob/feature/akka-typed/payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/ecpayment/issuing/IssuingServiceECPaymentApplicationImpl.scala#L54-L70)
  -  受信側
     - [trait AtLeastOnceDeliveryAcceptable](https://github.com/lerna-stack/lerna-sample-payment-app/blob/feature/akka-typed/payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/ecpayment/issuing/actor/Command.scala#L51-L66)
     - [lerna-sample-payment-app/PaymentActor.scala at feature/akka-typed · lerna-stack/lerna-sample-payment-app](https://github.com/lerna-stack/lerna-sample-payment-app/blob/feature/akka-typed/payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/ecpayment/issuing/actor/PaymentActor.scala#L188-L190)
     >         cancelRequest.accept()  
- ProcessingTimeout
  - [lerna-sample-payment-app/Command.scala at feature/akka-typed · lerna-stack/lerna-sample-payment-app](https://github.com/lerna-stack/lerna-sample-payment-app/blob/feature/akka-typed/payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/ecpayment/issuing/actor/Command.scala#L31-L40)