### PR TITLE
CI での ドキュメントの lint を有効にする

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Compile
         run: sbt clean compile test:compile
 
+      - name: Lint documentations
+        run: sbt doc mdoc
+
       - name: Check binary compartibility
         run: sbt mimaReportBinaryIssues
 


### PR DESCRIPTION
[[DONT MERGE] CI でドキュメントで使用されているコードのエラーを検知する by xirc · Pull Request #10 · lerna-stack/lerna-app-library](https://github.com/lerna-stack/lerna-app-library/pull/10) の PR にて、CI が意図通りにドキュメントを lint  できることを確認できます。

Scaladoc を生成する際には次のコマンドを使います。
```
sbt doc
```
Scaladoc に無効な参照などがある場合には、CIでエラーとなるようになります。
`doc/*.md` も同様に `sbt mdoc` でチェックすることができそうです。