### PR TITLE
[DONT MERGE] CI でドキュメントに使用されているコードのエラーを検知する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Compile
         run: sbt clean compile test:compile
 
+      - name: Lint documentations
+        run: sbt doc mdoc
+
       - name: Check binary compartibility
         run: sbt mimaReportBinaryIssues
 

--- a/doc/lerna-testkit.md
+++ b/doc/lerna-testkit.md
@@ -23,7 +23,7 @@ You can use this class like below.
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.{ ActorRef, Behavior }
 import lerna.testkit.akka.ScalaTestWithTypedActorTestKit
-import org.scalatest._
+import org.scalatt._
 
 final class MySpec extends ScalaTestWithTypedActorTestKit() with WordSpecLike with Matchers {
   import MySpec.Echo


### PR DESCRIPTION
ドキュメントのコードにエラーがある場合にCI が失敗することを確認できます。

[CI での ドキュメントの lint を有効にする by xirc · Pull Request #9 · lerna-stack/lerna-app-library](https://github.com/lerna-stack/lerna-app-library/pull/9) がマージされた or クローズされた場合に、この PR はマージせずにクローズします。