### PR TITLE
sbt-scoverage 1.8.1 に更新する

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -120,7 +120,7 @@ lazy val excludeSbtJavaOptions = Set(
 // TODO Make own wartremover settings
 
 lazy val lernaCoverageSettings = Def.settings(
-  coverageMinimum := 80,
+  coverageMinimumStmtTotal := 80,
   coverageFailOnMinimum := false,
   coverageExcludedPackages := Seq(
     // Exclude auto generated code by ScalaPB

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.10")
 
 addSbtPlugin("org.wartremover" % "sbt-wartremover-contrib" % "1.3.1")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.8.1")
 
 // ScalaPB
 addSbtPlugin("com.thesamet"                    % "sbt-protoc"     % "1.0.0-RC3")


### PR DESCRIPTION
[Scala 2.13 への移行をしたい · Issue #12 · lerna-stack/lerna-app-library](https://github.com/lerna-stack/lerna-app-library/issues/12) を実現するために必要です。
リリースノートは、[Releases · scoverage/sbt-scoverage](https://github.com/scoverage/sbt-scoverage/releases) から確認できます。


- sbt-scoverage 1.6.0+ から Scala 2.13 がサポートされます。
- sbt-scoverage 1.8.0+ から `coverageMinimum` は非推奨となりました。  
   - [Release sbt-scoverage v1.8.0 · scoverage/sbt-scoverage](https://github.com/scoverage/sbt-scoverage/releases/tag/v1.8.0) にて詳細を確認できます。
   - `coverageMinimum` は、同じ意味の `coverageMinimumStmtTotal` に置き換えました。
