### PR TITLE
sbt-wartremover を 2.4.13 に更新する

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 
 addSbtPlugin("org.duhemm" % "sbt-errors-summary" % "0.6.3")
 
-addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.10")
+addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.13")
 
 addSbtPlugin("org.wartremover" % "sbt-wartremover-contrib" % "1.3.1")
 


### PR DESCRIPTION
Scala 2.13.4 を利用するため、
`sbt-wartremover` を `2.4.13` に更新します。

sbt-wartremover 2.4.13+ から Scala 2.13.4  で利用できます。
[org.wartremover : wartremover_2.13.4 - Maven Central Repository Search](https://search.maven.org/artifact/org.wartremover/wartremover_2.13.4)

sbt-wartremover 2.4.10 は Scala 2.13.3 までの対応になっているようです。
[org.wartremover : wartremover_2.13.3 - Maven Central Repository Search](https://search.maven.org/artifact/org.wartremover/wartremover_2.13.3)

## 補足事項

この PR では Scala 2.13.4 を利用するために必要な `sbt-wartremover 2.4.13` に更新します。
PR作成時点の最新版は `sbt-wartremover 2.4.15` ですが、最新版への更新は行っていません。
`sbt-wartremover 2.4.15` に更新するためには、
追加でいくつかの（もしかするとたくさんの）作業が必要になりそうなためです。

例えば、`sbt-wartremover 2.4.15` と `sbt 1.3.13` は次のようなエラーがでるため組み合わせることはできません。
```
[error] java.lang.NoSuchMethodError: sbt.Def$.ifS(Lsbt/internal/util/Init$Initialize;Lsbt/internal/util/Init$Initialize;Lsbt/internal/util/Init$Initialize;)Lsbt/internal/util/Init$Initialize;
```

`sbt 1.4.0` のリリースノート [Release 1.4.0 · sbt/sbt](https://github.com/sbt/sbt/releases/tag/v1.4.0) をみた推測ですが、
sbt-wartremover 2.4.14+ からは `sbt 1.4.0+` が必要になっているかもしれません。
`sbt` を `1.4.0+` にするためには、単に `sbt` のバージョンを上げるだけでなく、
追加の作業が必要がありそうでした。
例えば `sbt 1.4.0` に更新し、`sbt clean test:compile` すると、次のようなエラーがでます。
```
$ sbt clean test:compile
[info] welcome to sbt 1.4.0 (Oracle Corporation Java 1.8.0_211)
(truncated...)
[warn] note: a setting might still be used by a command; to exclude a key from this `lintUnused` check
[warn] either append it to `Global / excludeLintKeys` or call .withRank(KeyRanks.Invisible) on the key
[success] Total time: 0 s, completed 2021/05/27 12:44:01
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[info] Compiling 1 protobuf files to \lerna-app-library\lerna-util-akka\target\scala-2.12\src_managed\main\scalapb
[info] Compiling schema \lerna-app-library\lerna-util-akka\src\main\protobuf\at-least-once-delivery.proto
[info] compiling 9 Scala sources to \lerna-app-library\lerna-wart-core\target\scala-2.12\classes ...
[info] done compiling
[error] scala.MatchError: sbt.errorssummary.Reporter@49298ae3 (of class sbt.errorssummary.Reporter)
[error]         at sbt.Defaults$.compileIncrementalTaskImpl(Defaults.scala:2146)
[error]         at sbt.Defaults$.$anonfun$compileIncrementalTask$2(Defaults.scala:2099)
[error]         at sbt.internal.io.Retry$.apply(Retry.scala:40)
[error]         at sbt.internal.io.Retry$.apply(Retry.scala:23)
[error]         at sbt.internal.server.BspCompileTask$.compute(BspCompileTask.scala:31)
[error]         at sbt.Defaults$.$anonfun$compileIncrementalTask$1(Defaults.scala:2096)
[error]         at scala.Function1.$anonfun$compose$1(Function1.scala:49)
[error]         at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:62)
[error]         at sbt.std.Transform$$anon$4.work(Transform.scala:68)
[error]         at sbt.Execute.$anonfun$submit$2(Execute.scala:282)
[error]         at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:23)
[error]         at sbt.Execute.work(Execute.scala:291)
[error]         at sbt.Execute.$anonfun$submit$1(Execute.scala:282)
[error]         at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:265)
[error]         at sbt.CompletionService$$anon$2.call(CompletionService.scala:64)
[error]         at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error]         at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[error]         at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error]         at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[error]         at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[error]         at java.lang.Thread.run(Thread.java:748)
```