### PR TITLE
Metrics のテスト&ドキュメントを追加する

### DIFF
--- a/doc/lerna-management.md
+++ b/doc/lerna-management.md
@@ -72,3 +72,23 @@ counter.increment()
 val metricValueWithTenant: Future[Option[MetricsValue]] =
   metrics.getMetrics(MetricsKey("my-custom-metric-key-name", Option(exampleTenant)))
 ```
+
+### Supported metric types
+
+`Metrics` supports the following metrics.
+- Counters
+- Gauges
+- Histograms
+- Range Samplers
+
+We can see all metric types of *Kamon* on [here](https://kamon.io/docs/latest/core/metrics/).
+
+Although `Metrics` holds metric values as strings,
+the string can be converted to another *Scala* type.
+We can convert strings returned from `Metrics` as follows.
+
+- Counters (`Long`)
+- Gauges (`Double`)
+- Histograms (`Long`)  
+  `Metrics` returns an average of the Histogram's values.
+- Range Samplers (`Long`)


### PR DESCRIPTION
`Metrics` は次のメトリクスをサポートしているようなので、
それぞれのメトリクスに対するテスト&ドキュメントを追加します。

- Counters
- Gauages
- Histograms
- Range Samplers

*Kamon* のメトリクス一覧は次の URL から確認できます。
[Using the Metrics API | Kamon Documentation | Kamon](https://kamon.io/docs/latest/core/metrics/)

現時点では　`Metrics` は Timers をサポートしていないようです。
Timers をサポートしたいことは issue にしました。
[lerna-management の `Metrics` で Timers をサポートしたい · Issue #20 · lerna-stack/lerna-app-library](https://github.com/lerna-stack/lerna-app-library/issues/20)