### PR TITLE
chore: mima version up (0.9.2)

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -23,5 +23,5 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
 addSbtPlugin("com.jsuereth"   % "sbt-pgp"      % "2.0.1")
 
 // Compatibility check
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.8.1")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.9.2")
 addSbtPlugin("com.dwijnand" % "sbt-dynver"      % "4.1.1")


### PR DESCRIPTION
Release 0.9.2 · lightbend/mima
https://github.com/lightbend/mima/releases/tag/0.9.2

[v0.9 から package private を無視する](https://github.com/lightbend/mima/releases/tag/0.9.0)ようになり、無意味な除外設定をしなくて良くなります。