### PR TITLE
lerna-management: Typed 対応

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -280,8 +280,7 @@ lazy val lernaManagement = lernaModule("lerna-management")
       Dependencies.Akka.actor,
       Dependencies.Kamon.core,
       Dependencies.Kamon.systemMetrics,
-      Dependencies.Akka.testKit    % Test,
-      Dependencies.Akka.actorTyped % Test,
+      Dependencies.Akka.actorTestKitTyped % Test,
     ),
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -277,7 +277,7 @@ lazy val lernaManagement = lernaModule("lerna-management")
   .settings(wartremoverSettings, lernaCoverageSettings)
   .settings(
     libraryDependencies ++= Seq(
-      Dependencies.Akka.actor,
+      Dependencies.Akka.actorTyped,
       Dependencies.Kamon.core,
       Dependencies.Kamon.systemMetrics,
       Dependencies.Akka.actorTestKitTyped % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -280,7 +280,8 @@ lazy val lernaManagement = lernaModule("lerna-management")
       Dependencies.Akka.actor,
       Dependencies.Kamon.core,
       Dependencies.Kamon.systemMetrics,
-      Dependencies.Akka.testKit % Test,
+      Dependencies.Akka.testKit    % Test,
+      Dependencies.Akka.actorTyped % Test,
     ),
   )
 

--- a/lerna-management/src/main/mima-filters/1.0.0.backwards.excludes/25-typed-support.backwards.excludes
+++ b/lerna-management/src/main/mima-filters/1.0.0.backwards.excludes/25-typed-support.backwards.excludes
@@ -1,0 +1,16 @@
+# lerna.management.stats.Metrics の typed 対応
+# Actor 定義を typed 化した際に Command に replyTo を追加
+# 以下の理由から変更しても互換性に問題はない
+# - Command は node を跨がらない
+# - Command は package private なので lerna-management lib 以外から使用されない
+
+#  method copy(lerna.management.stats.MetricsKey)lerna.management.stats.MetricsActor#GetMetrics in class lerna.management.stats.MetricsActor#GetMetrics does not have a correspondent in current version
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.management.stats.MetricsActor#GetMetrics.copy")
+#  method this(lerna.management.stats.MetricsKey)Unit in class lerna.management.stats.MetricsActor#GetMetrics does not have a correspondent in current version
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.management.stats.MetricsActor#GetMetrics.this")
+#  the type hierarchy of object lerna.management.stats.MetricsActor#GetMetrics is different in current version. Missing types {scala.runtime.AbstractFunction1}
+ProblemFilters.exclude[MissingTypesProblem]("lerna.management.stats.MetricsActor$GetMetrics$")
+#  method apply(lerna.management.stats.MetricsKey)lerna.management.stats.MetricsActor#GetMetrics in object lerna.management.stats.MetricsActor#GetMetrics does not have a correspondent in current version
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.management.stats.MetricsActor#GetMetrics.apply")
+#  method unapply(lerna.management.stats.MetricsActor#GetMetrics)scala.Option in object lerna.management.stats.MetricsActor#GetMetrics has a different generic signature in current version, where it is (Llerna/management/stats/MetricsActor$GetMetrics;)Lscala/Option<Lscala/Tuple2<Llerna/management/stats/MetricsKey;Lakka/actor/typed/ActorRef<Lscala/Option<Llerna/management/stats/MetricsValue;>;>;>;>; rather than (Llerna/management/stats/MetricsActor$GetMetrics;)Lscala/Option<Llerna/management/stats/MetricsKey;>;. See https://github.com/lightbend/mima#incompatiblesignatureproblem
+ProblemFilters.exclude[IncompatibleSignatureProblem]("lerna.management.stats.MetricsActor#GetMetrics.unapply")

--- a/lerna-management/src/main/mima-filters/1.0.0.backwards.excludes/25-typed-support.backwards.excludes
+++ b/lerna-management/src/main/mima-filters/1.0.0.backwards.excludes/25-typed-support.backwards.excludes
@@ -1,9 +1,10 @@
 # lerna.management.stats.Metrics の typed 対応
-# Actor 定義を typed 化した際に Command に replyTo を追加
 # 以下の理由から変更しても互換性に問題はない
 # - Command は node を跨がらない
 # - Command は package private なので lerna-management lib 以外から使用されない
 
+
+# Actor 定義を typed 化した際に Command に replyTo を追加
 #  method copy(lerna.management.stats.MetricsKey)lerna.management.stats.MetricsActor#GetMetrics in class lerna.management.stats.MetricsActor#GetMetrics does not have a correspondent in current version
 ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.management.stats.MetricsActor#GetMetrics.copy")
 #  method this(lerna.management.stats.MetricsKey)Unit in class lerna.management.stats.MetricsActor#GetMetrics does not have a correspondent in current version
@@ -14,3 +15,12 @@ ProblemFilters.exclude[MissingTypesProblem]("lerna.management.stats.MetricsActor
 ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.management.stats.MetricsActor#GetMetrics.apply")
 #  method unapply(lerna.management.stats.MetricsActor#GetMetrics)scala.Option in object lerna.management.stats.MetricsActor#GetMetrics has a different generic signature in current version, where it is (Llerna/management/stats/MetricsActor$GetMetrics;)Lscala/Option<Lscala/Tuple2<Llerna/management/stats/MetricsKey;Lakka/actor/typed/ActorRef<Lscala/Option<Llerna/management/stats/MetricsValue;>;>;>;>; rather than (Llerna/management/stats/MetricsActor$GetMetrics;)Lscala/Option<Llerna/management/stats/MetricsKey;>;. See https://github.com/lightbend/mima#incompatiblesignatureproblem
 ProblemFilters.exclude[IncompatibleSignatureProblem]("lerna.management.stats.MetricsActor#GetMetrics.unapply")
+
+
+# Command trait の FQCN整理
+# the type hierarchy of class lerna.management.stats.MetricsActor#GetMetrics is different in current version. Missing types {lerna.management.stats.MetricsActorCommand}
+ProblemFilters.exclude[MissingTypesProblem]("lerna.management.stats.MetricsActor$GetMetrics")
+# the type hierarchy of class lerna.management.stats.MetricsActor#UpdateMetrics is different in current version. Missing types {lerna.management.stats.MetricsActorCommand}
+ProblemFilters.exclude[MissingTypesProblem]("lerna.management.stats.MetricsActor$UpdateMetrics")
+# interface lerna.management.stats.MetricsActorCommand does not have a correspondent in current version
+ProblemFilters.exclude[MissingClassProblem]("lerna.management.stats.MetricsActorCommand")

--- a/lerna-management/src/main/scala/lerna/management/stats/Metrics.scala
+++ b/lerna-management/src/main/scala/lerna/management/stats/Metrics.scala
@@ -1,6 +1,6 @@
 package lerna.management.stats
 
-import akka.actor.ActorSystem
+import akka.actor.{ ActorSystem, ClassicActorSystemProvider }
 import kamon.module.MetricReporter
 import lerna.log.AppLogging
 import lerna.util.tenant.Tenant
@@ -37,4 +37,7 @@ object Metrics {
     new MetricsImpl(system, tenants)
   }
 
+  def apply(system: ClassicActorSystemProvider, tenants: Set[Tenant]): Metrics = {
+    apply(system.classicSystem, tenants)
+  }
 }

--- a/lerna-management/src/main/scala/lerna/management/stats/MetricsActor.scala
+++ b/lerna-management/src/main/scala/lerna/management/stats/MetricsActor.scala
@@ -4,14 +4,12 @@ import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.{ ActorRef, Behavior }
 import lerna.util.lang.Equals._
 
-private[stats] sealed trait MetricsActorCommand
-
 private[stats] object MetricsActor {
 
-  def apply(): Behavior[MetricsActorCommand] = active(Map())
+  def apply(): Behavior[Command] = active(Map())
 
   @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
-  private def active(metricsMap: Map[MetricsKey, MetricsValue]): Behaviors.Receive[MetricsActorCommand] =
+  private def active(metricsMap: Map[MetricsKey, MetricsValue]): Behaviors.Receive[Command] =
     Behaviors.receiveMessage {
       case GetMetrics(key, replyTo) =>
         replyTo ! metricsMap.get(key)
@@ -25,6 +23,8 @@ private[stats] object MetricsActor {
         active(metricsMap.filterNot { case (k, _) => k === key })
     }
 
-  final case class UpdateMetrics(key: MetricsKey, value: Option[MetricsValue])          extends MetricsActorCommand
-  final case class GetMetrics(key: MetricsKey, replyTo: ActorRef[Option[MetricsValue]]) extends MetricsActorCommand
+  sealed trait Command
+
+  final case class UpdateMetrics(key: MetricsKey, value: Option[MetricsValue])          extends Command
+  final case class GetMetrics(key: MetricsKey, replyTo: ActorRef[Option[MetricsValue]]) extends Command
 }

--- a/lerna-management/src/test/scala/lerna/management/stats/MetricsSpec.scala
+++ b/lerna-management/src/test/scala/lerna/management/stats/MetricsSpec.scala
@@ -1,8 +1,9 @@
 package lerna.management.stats
 
 import akka.actor.{ typed, ActorSystem }
-import akka.actor.typed.scaladsl.adapter._
 import lerna.management.LernaManagementActorBaseSpec
+import lerna.testkit.akka.ScalaTestWithTypedActorTestKit
+import lerna.tests.LernaBaseSpec
 import lerna.util.tenant.Tenant
 
 final class MetricsSpec extends LernaManagementActorBaseSpec(ActorSystem("MetricsSpec")) {
@@ -14,9 +15,13 @@ final class MetricsSpec extends LernaManagementActorBaseSpec(ActorSystem("Metric
       val metrics = Metrics(system, Set(tenant1))
       metrics shouldBe a[MetricsImpl]
     }
+  }
+}
 
+final class MetricsTypedSpec extends ScalaTestWithTypedActorTestKit() with LernaBaseSpec {
+  "Metrics.apply" should {
     "create a default instance by typed ActorSystem" in {
-      val typedSystem: typed.ActorSystem[Nothing] = system.toTyped
+      val typedSystem: typed.ActorSystem[Nothing] = system
       val tenant1: Tenant = new Tenant {
         override def id: String = "dummy-1"
       }

--- a/lerna-management/src/test/scala/lerna/management/stats/MetricsSpec.scala
+++ b/lerna-management/src/test/scala/lerna/management/stats/MetricsSpec.scala
@@ -1,6 +1,7 @@
 package lerna.management.stats
 
-import akka.actor.ActorSystem
+import akka.actor.{ typed, ActorSystem }
+import akka.actor.typed.scaladsl.adapter._
 import lerna.management.LernaManagementActorBaseSpec
 import lerna.util.tenant.Tenant
 
@@ -11,6 +12,15 @@ final class MetricsSpec extends LernaManagementActorBaseSpec(ActorSystem("Metric
         override def id: String = "dummy-1"
       }
       val metrics = Metrics(system, Set(tenant1))
+      metrics shouldBe a[MetricsImpl]
+    }
+
+    "create a default instance by typed ActorSystem" in {
+      val typedSystem: typed.ActorSystem[Nothing] = system.toTyped
+      val tenant1: Tenant = new Tenant {
+        override def id: String = "dummy-1"
+      }
+      val metrics = Metrics(typedSystem, Set(tenant1))
       metrics shouldBe a[MetricsImpl]
     }
   }


### PR DESCRIPTION
https://github.com/lerna-stack/lerna-app-library/issues/11 ```v2.0.0 · Issue #11 · lerna-stack/lerna-app-library```

> Akka Classic 向けに提供している機能を Akka Typed 向けにも提供します

## 変更内容
`def apply(system: ClassicActorSystemProvider, tenants: Set[Tenant]): Metrics` method を追加した。

## 関連する問題
https://github.com/lerna-stack/lerna-app-library/issues/24 ```typed ActorSystem を new して使うと一部モジュールでエラー · Issue #24 · lerna-stack/lerna-app-library```

- クラシック Props を typed API (Behavior) に書き換える

を選択した。

Extension化は テナント情報 `tenants: Set[Tenant]` をコンストラクタに渡すことができないため、不可