### PR TITLE
chore: ScalaPB version up

### DIFF
--- a/lerna-util-akka/src/main/mima-filters/1.0.0.backwards.excludes/27-version-up-ScalaPB.backwards.excludes
+++ b/lerna-util-akka/src/main/mima-filters/1.0.0.backwards.excludes/27-version-up-ScalaPB.backwards.excludes
@@ -1,0 +1,23 @@
+# ScalaPB version up
+# method 呼び出しはライブラリ外からの呼び出しを考慮していないので非互換でも問題ない
+# JVM 間の互換性は protocol buffer によって保証されているので問題ない
+
+
+# static method merge(lerna.util.akka.protobuf.msg.AtLeastOnceDeliveryConfirm,com.google.protobuf.CodedInputStream)lerna.util.akka.protobuf.msg.AtLeastOnceDeliveryConfirm in class lerna.util.akka.protobuf.msg.AtLeastOnceDeliveryConfirm's type is different in current version, where it is (scalapb.GeneratedMessage,com.google.protobuf.CodedInputStream)scalapb.GeneratedMessage instead of (lerna.util.akka.protobuf.msg.AtLeastOnceDeliveryConfirm,com.google.protobuf.CodedInputStream)lerna.util.akka.protobuf.msg.AtLeastOnceDeliveryConfirm
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("lerna.util.akka.protobuf.msg.AtLeastOnceDeliveryConfirm.merge")
+# static method parseFrom(com.google.protobuf.CodedInputStream)scalapb.GeneratedMessage in class lerna.util.akka.protobuf.msg.AtLeastOnceDeliveryConfirm has a different result type in current version, where it is lerna.util.akka.protobuf.msg.AtLeastOnceDeliveryConfirm rather than scalapb.GeneratedMessage
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("lerna.util.akka.protobuf.msg.AtLeastOnceDeliveryConfirm.parseFrom")
+# method merge(lerna.util.akka.protobuf.msg.AtLeastOnceDeliveryConfirm,com.google.protobuf.CodedInputStream)lerna.util.akka.protobuf.msg.AtLeastOnceDeliveryConfirm in object lerna.util.akka.protobuf.msg.AtLeastOnceDeliveryConfirm does not have a correspondent in current version
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.util.akka.protobuf.msg.AtLeastOnceDeliveryConfirm.merge")
+# static method merge(lerna.util.akka.protobuf.msg.AtLeastOnceDeliveryRequest,com.google.protobuf.CodedInputStream)lerna.util.akka.protobuf.msg.AtLeastOnceDeliveryRequest in class lerna.util.akka.protobuf.msg.AtLeastOnceDeliveryRequest's type is different in current version, where it is (scalapb.GeneratedMessage,com.google.protobuf.CodedInputStream)scalapb.GeneratedMessage instead of (lerna.util.akka.protobuf.msg.AtLeastOnceDeliveryRequest,com.google.protobuf.CodedInputStream)lerna.util.akka.protobuf.msg.AtLeastOnceDeliveryRequest
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("lerna.util.akka.protobuf.msg.AtLeastOnceDeliveryRequest.merge")
+# static method parseFrom(com.google.protobuf.CodedInputStream)scalapb.GeneratedMessage in class lerna.util.akka.protobuf.msg.AtLeastOnceDeliveryRequest has a different result type in current version, where it is lerna.util.akka.protobuf.msg.AtLeastOnceDeliveryRequest rather than scalapb.GeneratedMessage
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("lerna.util.akka.protobuf.msg.AtLeastOnceDeliveryRequest.parseFrom")
+# method merge(lerna.util.akka.protobuf.msg.AtLeastOnceDeliveryRequest,com.google.protobuf.CodedInputStream)lerna.util.akka.protobuf.msg.AtLeastOnceDeliveryRequest in object lerna.util.akka.protobuf.msg.AtLeastOnceDeliveryRequest does not have a correspondent in current version
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.util.akka.protobuf.msg.AtLeastOnceDeliveryRequest.merge")
+# static method merge(lerna.util.akka.protobuf.msg.Payload,com.google.protobuf.CodedInputStream)lerna.util.akka.protobuf.msg.Payload in class lerna.util.akka.protobuf.msg.Payload's type is different in current version, where it is (scalapb.GeneratedMessage,com.google.protobuf.CodedInputStream)scalapb.GeneratedMessage instead of (lerna.util.akka.protobuf.msg.Payload,com.google.protobuf.CodedInputStream)lerna.util.akka.protobuf.msg.Payload
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("lerna.util.akka.protobuf.msg.Payload.merge")
+# static method parseFrom(com.google.protobuf.CodedInputStream)scalapb.GeneratedMessage in class lerna.util.akka.protobuf.msg.Payload has a different result type in current version, where it is lerna.util.akka.protobuf.msg.Payload rather than scalapb.GeneratedMessage
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("lerna.util.akka.protobuf.msg.Payload.parseFrom")
+# method merge(lerna.util.akka.protobuf.msg.Payload,com.google.protobuf.CodedInputStream)lerna.util.akka.protobuf.msg.Payload in object lerna.util.akka.protobuf.msg.Payload does not have a correspondent in current version
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.util.akka.protobuf.msg.Payload.merge")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,8 +9,8 @@ addSbtPlugin("org.wartremover" % "sbt-wartremover-contrib" % "1.3.1")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.8.1")
 
 // ScalaPB
-addSbtPlugin("com.thesamet"                    % "sbt-protoc"     % "1.0.0-RC3")
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.10.8"
+addSbtPlugin("com.thesamet"                    % "sbt-protoc"     % "1.0.2")
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.3"
 
 // Documentation
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "2.0.0")


### PR DESCRIPTION
scalapb/ScalaPB: Protocol buffer compiler for Scala.
https://github.com/scalapb/ScalaPB

## 関連
https://github.com/lerna-stack/lerna-app-library/issues/26 ```[GitHub CI] test がすべて実行されていないが、CI が pass してしまう · Issue #26 · lerna-stack/lerna-app-library```

※ 治るかどうかは不明だが、2回 CI 動いて 2回とも問題なかった

## 参考 自動生成コードの差分
```diff
diff --git a/lerna-util-akka/target/scala-2.13/src_managed/main/scalapb/lerna/util/akka/protobuf/msg/AtLeastOnceDeliveryConfirm.scala b/lerna-util-akka/target/scala-2.13/src_managed/main/scalapb/lerna/util/akka/protobuf/msg/AtLeastOnceDeliveryConfirm.scala
index d441391f5..a5284c04d 100644
--- a/lerna-util-akka/target/scala-2.13/src_managed/main/scalapb/lerna/util/akka/protobuf/msg/AtLeastOnceDeliveryConfirm.scala
+++ b/lerna-util-akka/target/scala-2.13/src_managed/main/scalapb/lerna/util/akka/protobuf/msg/AtLeastOnceDeliveryConfirm.scala
@@ -35,11 +35,12 @@ def getFieldByNumber(__fieldNumber: _root_.scala.Int): _root_.scala.Any = throw
     def getField(__field: _root_.scalapb.descriptors.FieldDescriptor): _root_.scalapb.descriptors.PValue = throw new MatchError(__field)
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToUnicodeString(this)
     def companion = lerna.util.akka.protobuf.msg.AtLeastOnceDeliveryConfirm
+    // @@protoc_insertion_point(GeneratedMessage[lerna.util.akka.protobuf.msg.AtLeastOnceDeliveryConfirm])
 }
 
 object AtLeastOnceDeliveryConfirm extends scalapb.GeneratedMessageCompanion[lerna.util.akka.protobuf.msg.AtLeastOnceDeliveryConfirm] {
   implicit def messageCompanion: scalapb.GeneratedMessageCompanion[lerna.util.akka.protobuf.msg.AtLeastOnceDeliveryConfirm] = this
-  def merge(`_message__`: lerna.util.akka.protobuf.msg.AtLeastOnceDeliveryConfirm, `_input__`: _root_.com.google.protobuf.CodedInputStream): lerna.util.akka.protobuf.msg.AtLeastOnceDeliveryConfirm = {
+  def parseFrom(`_input__`: _root_.com.google.protobuf.CodedInputStream): lerna.util.akka.protobuf.msg.AtLeastOnceDeliveryConfirm = {
     var `_unknownFields__`: _root_.scalapb.UnknownFieldSet.Builder = null
     var _done__ = false
     while (!_done__) {
@@ -48,23 +49,23 @@ def merge(`_message__`: lerna.util.akka.protobuf.msg.AtLeastOnceDeliveryConfirm,
         case 0 => _done__ = true
         case tag =>
           if (_unknownFields__ == null) {
-            _unknownFields__ = new _root_.scalapb.UnknownFieldSet.Builder(_message__.unknownFields)
+            _unknownFields__ = new _root_.scalapb.UnknownFieldSet.Builder()
           }
           _unknownFields__.parseField(tag, _input__)
       }
     }
     lerna.util.akka.protobuf.msg.AtLeastOnceDeliveryConfirm(
-        unknownFields = if (_unknownFields__ == null) _message__.unknownFields else _unknownFields__.result()
+        unknownFields = if (_unknownFields__ == null) _root_.scalapb.UnknownFieldSet.empty else _unknownFields__.result()
     )
   }
   implicit def messageReads: _root_.scalapb.descriptors.Reads[lerna.util.akka.protobuf.msg.AtLeastOnceDeliveryConfirm] = _root_.scalapb.descriptors.Reads{
     case _root_.scalapb.descriptors.PMessage(__fieldsMap) =>
-      _root_.scala.Predef.require(__fieldsMap.keys.forall(_.containingMessage == scalaDescriptor), "FieldDescriptor does not match message type.")
+      _root_.scala.Predef.require(__fieldsMap.keys.forall(_.containingMessage eq scalaDescriptor), "FieldDescriptor does not match message type.")
       lerna.util.akka.protobuf.msg.AtLeastOnceDeliveryConfirm(
       )
     case _ => throw new RuntimeException("Expected PMessage")
   }
-  def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = AtLeastOnceDeliveryProto.javaDescriptor.getMessageTypes.get(1)
+  def javaDescriptor: _root_.com.google.protobuf.Descriptors.Descriptor = AtLeastOnceDeliveryProto.javaDescriptor.getMessageTypes().get(1)
   def scalaDescriptor: _root_.scalapb.descriptors.Descriptor = AtLeastOnceDeliveryProto.scalaDescriptor.messages(1)
   def messageCompanionForFieldNumber(__number: _root_.scala.Int): _root_.scalapb.GeneratedMessageCompanion[_] = throw new MatchError(__number)
   lazy val nestedMessagesCompanions: Seq[_root_.scalapb.GeneratedMessageCompanion[_ <: _root_.scalapb.GeneratedMessage]] = Seq.empty
```