### PR TITLE
fix: AtLeastOnceDelivery: TypedSystem を 使用すると actor を作成できない問題に対処

### DIFF
--- a/lerna-util-akka/src/main/scala/lerna/util/akka/AtLeastOnceDelivery.scala
+++ b/lerna-util-akka/src/main/scala/lerna/util/akka/AtLeastOnceDelivery.scala
@@ -10,7 +10,6 @@ import akka.actor.{
   ExtendedActorSystem,
   Extension,
   ExtensionId,
-  ExtensionIdProvider,
   NoSerializationVerificationNeeded,
   Props,
 }
@@ -166,13 +165,9 @@ object AtLeastOnceDelivery {
   private def props(destination: ActorRef)(implicit requestContext: RequestContext) =
     Props(new AtLeastOnceDelivery(destination))
 
-  private object AtLeastOnceDeliveryExtensionForTyped
-      extends ExtensionId[AtLeastOnceDeliveryExtensionForTyped]
-      with ExtensionIdProvider {
+  private object AtLeastOnceDeliveryExtensionForTyped extends ExtensionId[AtLeastOnceDeliveryExtensionForTyped] {
     override def createExtension(system: ExtendedActorSystem): AtLeastOnceDeliveryExtensionForTyped =
       new AtLeastOnceDeliveryExtensionForTyped(system)
-
-    override def lookup(): ExtensionId[_ <: Extension] = this
   }
 
   private class AtLeastOnceDeliveryExtensionForTyped(system: ExtendedActorSystem) extends Extension {


### PR DESCRIPTION
## 原因
> java.lang.UnsupportedOperationException: cannot create top-level actor from the outside on ActorSystem with custom user guardian

typedSystem.toClassic.actorOf が使えるのは元々クラシックActorSystem の場合のみ。

## 対策
Extension 化し ExtendedActorSystem の `def systemActorOf(props: Props, name: String): ActorRef` 経由で actor を作成するようにした

[Classic Akka Extensions • Akka Documentation](https://doc.akka.io/docs/akka/current/extending-akka.html)

## 関連
https://github.com/lerna-stack/lerna-app-library/issues/24 ```typed ActorSystem を new して使うと一部モジュールでエラー · Issue #24 · lerna-stack/lerna-app-library```

## 備考
まだ、CIがグリーンなのに実際には落ちている問題は発生しています 

[fix: AtLeastOnceDelivery: TypedSystem を 使用すると actor を作成できない問題に対処 by tksugimoto · Pull Request #28 · lerna-stack/lerna-app-library](https://github.com/lerna-stack/lerna-app-library/pull/28/checks?check_run_id=2791942338#step:12:736)

> Error:  java.nio.file.NoSuchFileException: /home/runner/work/lerna-app-library/lerna-app-library/lerna-util-akka/target/scala-2.12/src_managed/main/scalapb/lerna/util/akka/protobuf/msg/AtLeastOnceDeliveryRequest.scala  

が、ScalaPB version up のPR

https://github.com/lerna-stack/lerna-app-library/pull/27 ```chore: ScalaPB version up by tksugimoto · Pull Request #27 · lerna-stack/lerna-app-library```

を この修正PRから伸ばして ERRORなし

[chore: ScalaPB version up by tksugimoto · Pull Request #27 · lerna-stack/lerna-app-library](https://github.com/lerna-stack/lerna-app-library/pull/27/checks?check_run_id=2791733285#step:12:1490)

> [info] AtLeastOnceDeliveryTypedSpec:  
> [info] askTo()  
> [info] - should 宛先に到達保証用メッセージを送信できる  
> [info] - should confirm されない場合は再送する  
> [info] - should retry-timeout時間経過しても confirm されなかった場合再送を中止する  
> [info] tellTo()  
> [info] - should 宛先に到達保証用メッセージを送信できる  
> [info] - should confirm されない場合は再送する  
> [info] - should retry-timeout時間経過しても confirm されなかった場合再送を中止する  

を確認済みです。
※ protobuf 用自動生成ファイルで失敗していると AtLeastOnceDeliveryTypedSpec が実行されない