### PR TITLE
Typed/lerna util sequence

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -353,7 +353,7 @@ lazy val lernaUtilSequence = lernaModule("lerna-util-sequence")
   .settings(
     libraryDependencies ++= Seq(
       Dependencies.DataStax.cassandraDriverCore,
-      Dependencies.Akka.actor,
+      Dependencies.Akka.actorTyped,
       Dependencies.Akka.actorTestKitTyped % Test,
     ),
   )

--- a/build.sbt
+++ b/build.sbt
@@ -354,7 +354,7 @@ lazy val lernaUtilSequence = lernaModule("lerna-util-sequence")
     libraryDependencies ++= Seq(
       Dependencies.DataStax.cassandraDriverCore,
       Dependencies.Akka.actor,
-      Dependencies.Akka.testKit % Test,
+      Dependencies.Akka.actorTestKitTyped % Test,
     ),
   )
 

--- a/lerna-util-sequence/src/main/mima-filters/1.0.0.backwards.excludes/29-typed-support.backwards.excludes
+++ b/lerna-util-sequence/src/main/mima-filters/1.0.0.backwards.excludes/29-typed-support.backwards.excludes
@@ -1,0 +1,8 @@
+# typed ActorSystem 対応
+# ClassicActorSystemProvider は typed/classic 両方の ActorSystem が継承しているので compileエラーにはならない
+# ※ Akka 2.6 以上のみ対応
+
+# abstract method system()akka.actor.ActorSystem in class lerna.util.sequence.CassandraSequenceFactory has a different result type in current version, where it is akka.actor.ClassicActorSystemProvider rather than akka.actor.ActorSystem
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("lerna.util.sequence.CassandraSequenceFactory.system")
+# abstract method system()akka.actor.ClassicActorSystemProvider in class lerna.util.sequence.CassandraSequenceFactory is present only in current version
+ProblemFilters.exclude[ReversedMissingMethodProblem]("lerna.util.sequence.CassandraSequenceFactory.system")

--- a/lerna-util-sequence/src/main/mima-filters/1.0.0.backwards.excludes/29-typed-support.backwards.excludes
+++ b/lerna-util-sequence/src/main/mima-filters/1.0.0.backwards.excludes/29-typed-support.backwards.excludes
@@ -6,3 +6,62 @@
 ProblemFilters.exclude[IncompatibleResultTypeProblem]("lerna.util.sequence.CassandraSequenceFactory.system")
 # abstract method system()akka.actor.ClassicActorSystemProvider in class lerna.util.sequence.CassandraSequenceFactory is present only in current version
 ProblemFilters.exclude[ReversedMissingMethodProblem]("lerna.util.sequence.CassandraSequenceFactory.system")
+
+
+# Behavior 化 にともなう内部 Actor の Message 変更
+# - 同一JVM 内でのみ使用されシリアライズされることはない
+# - ライブラリ(lerna.util.sequence)内部でのみ使用され外部から直接参照されることはない
+# method copy(scala.Option)lerna.util.sequence.SequenceFactoryWorker#GenerateSequence in class lerna.util.sequence.SequenceFactoryWorker#GenerateSequence does not have a correspondent in current version
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.util.sequence.SequenceFactoryWorker#GenerateSequence.copy")
+# method this(scala.Option)Unit in class lerna.util.sequence.SequenceFactoryWorker#GenerateSequence does not have a correspondent in current version
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.util.sequence.SequenceFactoryWorker#GenerateSequence.this")
+# the type hierarchy of object lerna.util.sequence.SequenceFactoryWorker#GenerateSequence is different in current version. Missing types {scala.runtime.AbstractFunction1}
+ProblemFilters.exclude[MissingTypesProblem]("lerna.util.sequence.SequenceFactoryWorker$GenerateSequence$")
+# method apply(scala.Option)lerna.util.sequence.SequenceFactoryWorker#GenerateSequence in object lerna.util.sequence.SequenceFactoryWorker#GenerateSequence does not have a correspondent in current version
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.util.sequence.SequenceFactoryWorker#GenerateSequence.apply")
+# method unapply(lerna.util.sequence.SequenceFactoryWorker#GenerateSequence)scala.Option in object lerna.util.sequence.SequenceFactoryWorker#GenerateSequence has a different generic signature in current version, where it is (Llerna/util/sequence/SequenceFactoryWorker$GenerateSequence;)Lscala/Option<Lscala/Tuple2<Lscala/Option<Ljava/lang/String;>;Lakka/actor/typed/ActorRef<Llerna/util/sequence/SequenceFactoryWorker$SequenceGenerated;>;>;>; rather than (Llerna/util/sequence/SequenceFactoryWorker$GenerateSequence;)Lscala/Option<Lscala/Option<Ljava/lang/String;>;>;. See https://github.com/lightbend/mima#incompatiblesignatureproblem
+ProblemFilters.exclude[IncompatibleSignatureProblem]("lerna.util.sequence.SequenceFactoryWorker#GenerateSequence.unapply")
+# interface lerna.util.sequence.SequenceStore#DomainEvent does not have a correspondent in current version
+ProblemFilters.exclude[MissingClassProblem]("lerna.util.sequence.SequenceStore$DomainEvent")
+# method copy(scala.math.BigInt,Int,scala.Option)lerna.util.sequence.SequenceStore#InitialReserveSequence in class lerna.util.sequence.SequenceStore#InitialReserveSequence does not have a correspondent in current version
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.util.sequence.SequenceStore#InitialReserveSequence.copy")
+# method this(scala.math.BigInt,Int,scala.Option)Unit in class lerna.util.sequence.SequenceStore#InitialReserveSequence does not have a correspondent in current version
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.util.sequence.SequenceStore#InitialReserveSequence.this")
+# the type hierarchy of object lerna.util.sequence.SequenceStore#InitialReserveSequence is different in current version. Missing types {scala.runtime.AbstractFunction3}
+ProblemFilters.exclude[MissingTypesProblem]("lerna.util.sequence.SequenceStore$InitialReserveSequence$")
+# method apply(scala.math.BigInt,Int,scala.Option)lerna.util.sequence.SequenceStore#InitialReserveSequence in object lerna.util.sequence.SequenceStore#InitialReserveSequence does not have a correspondent in current version
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.util.sequence.SequenceStore#InitialReserveSequence.apply")
+# method unapply(lerna.util.sequence.SequenceStore#InitialReserveSequence)scala.Option in object lerna.util.sequence.SequenceStore#InitialReserveSequence has a different generic signature in current version, where it is (Llerna/util/sequence/SequenceStore$InitialReserveSequence;)Lscala/Option<Lscala/Tuple4<Lscala/math/BigInt;Ljava/lang/Object;Lscala/Option<Ljava/lang/String;>;Lakka/actor/typed/ActorRef<Llerna/util/sequence/SequenceStore$ReservationResponse;>;>;>; rather than (Llerna/util/sequence/SequenceStore$InitialReserveSequence;)Lscala/Option<Lscala/Tuple3<Lscala/math/BigInt;Ljava/lang/Object;Lscala/Option<Ljava/lang/String;>;>;>;. See https://github.com/lightbend/mima#incompatiblesignatureproblem
+ProblemFilters.exclude[IncompatibleSignatureProblem]("lerna.util.sequence.SequenceStore#InitialReserveSequence.unapply")
+# the type hierarchy of class lerna.util.sequence.SequenceStore#InitialSequenceReserved is different in current version. Missing types {lerna.util.sequence.SequenceStore$DomainEvent}
+ProblemFilters.exclude[MissingTypesProblem]("lerna.util.sequence.SequenceStore$InitialSequenceReserved")
+# the type hierarchy of object lerna.util.sequence.SequenceStore#ReservationFailed is different in current version. Missing types {lerna.util.sequence.SequenceStore$DomainEvent}
+ProblemFilters.exclude[MissingTypesProblem]("lerna.util.sequence.SequenceStore$ReservationFailed$")
+# method copy(scala.math.BigInt,Int,scala.Option)lerna.util.sequence.SequenceStore#ReserveSequence in class lerna.util.sequence.SequenceStore#ReserveSequence does not have a correspondent in current version
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.util.sequence.SequenceStore#ReserveSequence.copy")
+# method this(scala.math.BigInt,Int,scala.Option)Unit in class lerna.util.sequence.SequenceStore#ReserveSequence does not have a correspondent in current version
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.util.sequence.SequenceStore#ReserveSequence.this")
+# the type hierarchy of object lerna.util.sequence.SequenceStore#ReserveSequence is different in current version. Missing types {scala.runtime.AbstractFunction3}
+ProblemFilters.exclude[MissingTypesProblem]("lerna.util.sequence.SequenceStore$ReserveSequence$")
+# method apply(scala.math.BigInt,Int,scala.Option)lerna.util.sequence.SequenceStore#ReserveSequence in object lerna.util.sequence.SequenceStore#ReserveSequence does not have a correspondent in current version
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.util.sequence.SequenceStore#ReserveSequence.apply")
+# method unapply(lerna.util.sequence.SequenceStore#ReserveSequence)scala.Option in object lerna.util.sequence.SequenceStore#ReserveSequence has a different generic signature in current version, where it is (Llerna/util/sequence/SequenceStore$ReserveSequence;)Lscala/Option<Lscala/Tuple4<Lscala/math/BigInt;Ljava/lang/Object;Lscala/Option<Ljava/lang/String;>;Lakka/actor/typed/ActorRef<Llerna/util/sequence/SequenceStore$ReservationResponse;>;>;>; rather than (Llerna/util/sequence/SequenceStore$ReserveSequence;)Lscala/Option<Lscala/Tuple3<Lscala/math/BigInt;Ljava/lang/Object;Lscala/Option<Ljava/lang/String;>;>;>;. See https://github.com/lightbend/mima#incompatiblesignatureproblem
+ProblemFilters.exclude[IncompatibleSignatureProblem]("lerna.util.sequence.SequenceStore#ReserveSequence.unapply")
+# method copy(scala.math.BigInt,Int,scala.Option)lerna.util.sequence.SequenceStore#ResetReserveSequence in class lerna.util.sequence.SequenceStore#ResetReserveSequence does not have a correspondent in current version
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.util.sequence.SequenceStore#ResetReserveSequence.copy")
+# method this(scala.math.BigInt,Int,scala.Option)Unit in class lerna.util.sequence.SequenceStore#ResetReserveSequence does not have a correspondent in current version
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.util.sequence.SequenceStore#ResetReserveSequence.this")
+# the type hierarchy of object lerna.util.sequence.SequenceStore#ResetReserveSequence is different in current version. Missing types {scala.runtime.AbstractFunction3}
+ProblemFilters.exclude[MissingTypesProblem]("lerna.util.sequence.SequenceStore$ResetReserveSequence$")
+# method apply(scala.math.BigInt,Int,scala.Option)lerna.util.sequence.SequenceStore#ResetReserveSequence in object lerna.util.sequence.SequenceStore#ResetReserveSequence does not have a correspondent in current version
+ProblemFilters.exclude[DirectMissingMethodProblem]("lerna.util.sequence.SequenceStore#ResetReserveSequence.apply")
+# method unapply(lerna.util.sequence.SequenceStore#ResetReserveSequence)scala.Option in object lerna.util.sequence.SequenceStore#ResetReserveSequence has a different generic signature in current version, where it is (Llerna/util/sequence/SequenceStore$ResetReserveSequence;)Lscala/Option<Lscala/Tuple4<Lscala/math/BigInt;Ljava/lang/Object;Lscala/Option<Ljava/lang/String;>;Lakka/actor/typed/ActorRef<Llerna/util/sequence/SequenceStore$ReservationResponse;>;>;>; rather than (Llerna/util/sequence/SequenceStore$ResetReserveSequence;)Lscala/Option<Lscala/Tuple3<Lscala/math/BigInt;Ljava/lang/Object;Lscala/Option<Ljava/lang/String;>;>;>;. See https://github.com/lightbend/mima#incompatiblesignatureproblem
+ProblemFilters.exclude[IncompatibleSignatureProblem]("lerna.util.sequence.SequenceStore#ResetReserveSequence.unapply")
+# the type hierarchy of class lerna.util.sequence.SequenceStore#SequenceReserved is different in current version. Missing types {lerna.util.sequence.SequenceStore$DomainEvent}
+ProblemFilters.exclude[MissingTypesProblem]("lerna.util.sequence.SequenceStore$SequenceReserved")
+# the type hierarchy of class lerna.util.sequence.SequenceStore#SequenceReset is different in current version. Missing types {lerna.util.sequence.SequenceStore$DomainEvent}
+ProblemFilters.exclude[MissingTypesProblem]("lerna.util.sequence.SequenceStore$SequenceReset")
+# the type hierarchy of class lerna.util.sequence.SequenceStore#SessionOpened is different in current version. Missing types {lerna.util.sequence.SequenceStore$DomainEvent}
+ProblemFilters.exclude[MissingTypesProblem]("lerna.util.sequence.SequenceStore$SessionOpened")
+# the type hierarchy of class lerna.util.sequence.SequenceStore#SessionPrepared is different in current version. Missing types {lerna.util.sequence.SequenceStore$DomainEvent}
+ProblemFilters.exclude[MissingTypesProblem]("lerna.util.sequence.SequenceStore$SessionPrepared")

--- a/lerna-util-sequence/src/main/resources/reference.conf
+++ b/lerna-util-sequence/src/main/resources/reference.conf
@@ -13,6 +13,9 @@ lerna.util.sequence {
   # 確保したシーケンスをインメモリに持つ、ワーカーを開放するまでの時間
   worker.idle-timeout = 10s
 
+  worker.stash-capacity = 1000
+  store.stash-capacity = 1000
+
   cassandra {
     tenants = {
       // example = ${lerna.util.sequence.cassandra.default}

--- a/lerna-util-sequence/src/main/resources/reference.conf
+++ b/lerna-util-sequence/src/main/resources/reference.conf
@@ -13,7 +13,18 @@ lerna.util.sequence {
   # 確保したシーケンスをインメモリに持つ、ワーカーを開放するまでの時間
   worker.idle-timeout = 10s
 
+  # ワーカーで処理中の際にメッセージをバッファーする上限
+  # 上限を超えた場合、Actorは再起動し処理中のメッセージは失われ(レスポンスされない)タイムアウトする
+  # 参考: https://doc.akka.io/docs/akka/current/typed/stash.html
+  # 処理要求が多すぎてバッファーが耐えられなくなると akka.actor.typed.javadsl.StashOverflowException が throw される。
+  # その場合、 stash-capacity を大きくするべき。ただし、メモリ使用量は増加する。
   worker.stash-capacity = 1000
+
+  # ストアで処理中の際にメッセージをバッファーする上限
+  # 上限を超えた場合、Actorは再起動し処理中のメッセージは失われ(レスポンスされない)タイムアウトする
+  # 参考: https://doc.akka.io/docs/akka/current/typed/stash.html
+  # 処理要求が多すぎてバッファーが耐えられなくなると akka.actor.typed.javadsl.StashOverflowException が throw される。
+  # その場合、 stash-capacity を大きくするべき。ただし、メモリ使用量は増加する。
   store.stash-capacity = 1000
 
   cassandra {

--- a/lerna-util-sequence/src/main/scala/lerna/util/sequence/CassandraSequenceFactory.scala
+++ b/lerna-util-sequence/src/main/scala/lerna/util/sequence/CassandraSequenceFactory.scala
@@ -88,7 +88,7 @@ abstract class CassandraSequenceFactory extends SequenceFactory with AppLogging 
 
   private[this] implicit val generateTimeout: Timeout = Timeout(sequenceConfig.generateTimeout)
 
-  private[this] implicit def ec: ExecutionContextExecutor = system.classicSystem.dispatcher
+  private[this] implicit def ec: ExecutionContextExecutor = typedSystem.executionContext
 
   private[this] def encode(str: String) = URLEncoder.encode(str, StandardCharsets.UTF_8.name)
 

--- a/lerna-util-sequence/src/main/scala/lerna/util/sequence/SequenceFactorySupervisor.scala
+++ b/lerna-util-sequence/src/main/scala/lerna/util/sequence/SequenceFactorySupervisor.scala
@@ -39,8 +39,8 @@ private[sequence] final class SequenceFactorySupervisor(
       val worker =
         context
           .child(workerNameOf(sequenceSubId))
-          // FIXME: `asInstanceOf` https://doc.akka.io/docs/akka/current/typed/from-classic.html#actorcontext-children
-          .map(_.asInstanceOf[ActorRef[SequenceFactoryWorker.Command]])
+          // FIXME: `unsafeUpcast` https://doc.akka.io/docs/akka/current/typed/from-classic.html#actorcontext-children
+          .map(_.unsafeUpcast[SequenceFactoryWorker.Command])
           .getOrElse(createWorker(sequenceSubId))
 
       worker ! command

--- a/lerna-util-sequence/src/main/scala/lerna/util/sequence/SequenceFactorySupervisor.scala
+++ b/lerna-util-sequence/src/main/scala/lerna/util/sequence/SequenceFactorySupervisor.scala
@@ -33,7 +33,7 @@ private[sequence] final class SequenceFactorySupervisor(
 
   private[this] val store = createSequenceStore()
 
-  def createBehavior(): Behaviors.Receive[SequenceFactoryWorker.GenerateSequence] =
+  def createBehavior(): Behavior[SequenceFactoryWorker.GenerateSequence] =
     Behaviors.receiveMessage[SequenceFactoryWorker.GenerateSequence] { command =>
       val sequenceSubId = command.sequenceSubId
       val worker =

--- a/lerna-util-sequence/src/main/scala/lerna/util/sequence/SequenceFactorySupervisor.scala
+++ b/lerna-util-sequence/src/main/scala/lerna/util/sequence/SequenceFactorySupervisor.scala
@@ -76,16 +76,10 @@ private[sequence] final class SequenceFactorySupervisor(
 
     // SupervisorStrategy
     // see: https://docs.datastax.com/en/developer/java-driver/3.6/manual/retries/#retry-policy
-    behavior = Behaviors.supervise(behavior).onFailure[NoHostAvailableException](SupervisorStrategy.restart)
-    behavior = Behaviors.supervise(behavior).onFailure[UnsupportedFeatureException](SupervisorStrategy.restart)
     // 一時的にレプリカが処理できなくなっているだけなので、Cassandra サイドで回復することを期待する
     behavior = Behaviors.supervise(behavior).onFailure[ReadTimeoutException](SupervisorStrategy.resume)
     // 一時的にレプリカが処理できなくなっているだけなので、Cassandra サイドで回復することを期待する
     behavior = Behaviors.supervise(behavior).onFailure[WriteTimeoutException](SupervisorStrategy.resume)
-    // コーディネーターに何らかの問題が起きている可能性がある。再接続して回復することを期待する
-    behavior = Behaviors.supervise(behavior).onFailure[OperationTimedOutException](SupervisorStrategy.restart)
-    // コネクションに問題がある。再接続して回復することを期待する
-    behavior = Behaviors.supervise(behavior).onFailure[ConnectionException](SupervisorStrategy.restart)
     behavior = Behaviors.supervise(behavior).onFailure[Exception](SupervisorStrategy.restart)
 
     context.spawn(

--- a/lerna-util-sequence/src/main/scala/lerna/util/sequence/SequenceFactorySupervisor.scala
+++ b/lerna-util-sequence/src/main/scala/lerna/util/sequence/SequenceFactorySupervisor.scala
@@ -1,103 +1,98 @@
 package lerna.util.sequence
 
-import akka.actor.SupervisorStrategy._
-import akka.actor.{ Actor, ActorRef, OneForOneStrategy, Props, SupervisorStrategy }
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors }
+import akka.actor.typed.{ ActorRef, Behavior, SupervisorStrategy }
 import com.datastax.driver.core.exceptions._
-import lerna.log.AppActorLogging
+import lerna.util.sequence.SequenceStore.Command
 import lerna.util.tenant.Tenant
 
 private[sequence] object SequenceFactorySupervisor {
 
-  def props(sequenceId: String, maxSequenceValue: BigInt, reservationAmount: Int)(implicit tenant: Tenant): Props =
-    Props(
-      new SequenceFactorySupervisor(
-        sequenceId = sequenceId,
-        maxSequenceValue = maxSequenceValue,
-        reservationAmount = reservationAmount,
-      ),
-    )
-
+  def apply(sequenceId: String, maxSequenceValue: BigInt, reservationAmount: Int)(implicit
+      tenant: Tenant,
+  ): Behavior[SequenceFactoryWorker.GenerateSequence] = Behaviors
+    .supervise[SequenceFactoryWorker.GenerateSequence](
+      Behaviors.setup { context =>
+        new SequenceFactorySupervisor(
+          sequenceId = sequenceId,
+          maxSequenceValue = maxSequenceValue,
+          reservationAmount = reservationAmount,
+          context,
+        ).receive
+      },
+    ).onFailure[Exception](SupervisorStrategy.restart)
 }
 
 private[sequence] final class SequenceFactorySupervisor(
     sequenceId: String,
     maxSequenceValue: BigInt,
     reservationAmount: Int,
-)(implicit tenant: Tenant)
-    extends Actor
-    with AppActorLogging {
-
-  import lerna.util.tenant.TenantComponentLogContext.logContext
+    context: ActorContext[SequenceFactoryWorker.GenerateSequence],
+)(implicit tenant: Tenant) {
 
   private[this] val config = new SequenceFactoryConfig(context.system.settings.config)
 
   private[this] val store = createSequenceStore()
 
-  override def receive: Receive = {
-    case command @ SequenceFactoryWorker.GenerateSequence(sequenceSubId) =>
+  def receive: Behaviors.Receive[SequenceFactoryWorker.GenerateSequence] =
+    Behaviors.receiveMessage[SequenceFactoryWorker.GenerateSequence] { command =>
+      val sequenceSubId = command.sequenceSubId
       val worker =
         context
           .child(workerNameOf(sequenceSubId))
+          // FIXME: `asInstanceOf` https://doc.akka.io/docs/akka/current/typed/from-classic.html#actorcontext-children
+          .map(_.asInstanceOf[ActorRef[SequenceFactoryWorker.Command]])
           .getOrElse(createWorker(sequenceSubId))
 
-      worker forward command
-  }
-
-  // see: https://docs.datastax.com/en/developer/java-driver/3.6/manual/retries/#retry-policy
-  override def supervisorStrategy: SupervisorStrategy =
-    OneForOneStrategy(loggingEnabled = false) {
-      case e: NoHostAvailableException =>
-        logger.warn(e, "Cassandra is not available")
-        Restart
-      case e: UnsupportedFeatureException =>
-        logger.warn(e, "Illegal operation detected")
-        Restart
-      case e: ReadTimeoutException =>
-        // 一時的にレプリカが処理できなくなっているだけなので、Cassandra サイドで回復することを期待する
-        logger.warn(e, "Read query failed. Resuming SequenceStore")
-        Resume
-      case e: WriteTimeoutException =>
-        // 一時的にレプリカが処理できなくなっているだけなので、Cassandra サイドで回復することを期待する
-        logger.warn(e, "Write query failed. Resuming SequenceStore")
-        Resume
-      case e: OperationTimedOutException =>
-        // コーディネーターに何らかの問題が起きている可能性がある。再接続して回復することを期待する
-        logger.warn(e, "Query failed. Re-establishing connection")
-        Restart
-      case e: ConnectionException =>
-        // コネクションに問題がある。再接続して回復することを期待する
-        logger.warn(e, "Connection broken. Re-establishing connection")
-        Restart
-      case e =>
-        logger.warn(e, "Unexpected error detected")
-        Restart
+      worker ! command
+      Behaviors.same
     }
 
-  private def createWorker(sequenceSubId: Option[String]): ActorRef =
-    context.actorOf(
-      SequenceFactoryWorker.props(
-        maxSequenceValue = maxSequenceValue,
-        firstValue = config.firstValue,
-        incrementStep = config.incrementStep,
-        reservationAmount = reservationAmount,
-        sequenceStore = store,
-        idleTimeout = config.workerIdleTimeout,
-        sequenceSubId = sequenceSubId,
-      ),
+  private def createWorker(sequenceSubId: Option[String]): ActorRef[SequenceFactoryWorker.Command] =
+    context.spawn(
+      Behaviors
+        .supervise(
+          SequenceFactoryWorker.apply(
+            maxSequenceValue = maxSequenceValue,
+            firstValue = config.firstValue,
+            incrementStep = config.incrementStep,
+            reservationAmount = reservationAmount,
+            sequenceStore = store,
+            idleTimeout = config.workerIdleTimeout,
+            sequenceSubId = sequenceSubId,
+          ),
+        ).onFailure[Exception](SupervisorStrategy.restart),
       workerNameOf(sequenceSubId),
     )
 
-  private def createSequenceStore(): ActorRef =
-    context.actorOf(
-      SequenceStore
-        .props(
-          sequenceId = sequenceId,
-          nodeId = config.nodeId,
-          incrementStep = config.incrementStep,
-          config = config.cassandraConfig,
-        ),
+  private def createSequenceStore(): ActorRef[SequenceStore.Command] = {
+    @SuppressWarnings(Array("org.wartremover.warts.Var"))
+    var behavior: Behavior[Command] = SequenceStore.apply(
+      sequenceId = sequenceId,
+      nodeId = config.nodeId,
+      incrementStep = config.incrementStep,
+      config = config.cassandraConfig,
+    )
+
+    // SupervisorStrategy
+    // see: https://docs.datastax.com/en/developer/java-driver/3.6/manual/retries/#retry-policy
+    behavior = Behaviors.supervise(behavior).onFailure[NoHostAvailableException](SupervisorStrategy.restart)
+    behavior = Behaviors.supervise(behavior).onFailure[UnsupportedFeatureException](SupervisorStrategy.restart)
+    // 一時的にレプリカが処理できなくなっているだけなので、Cassandra サイドで回復することを期待する
+    behavior = Behaviors.supervise(behavior).onFailure[ReadTimeoutException](SupervisorStrategy.resume)
+    // 一時的にレプリカが処理できなくなっているだけなので、Cassandra サイドで回復することを期待する
+    behavior = Behaviors.supervise(behavior).onFailure[WriteTimeoutException](SupervisorStrategy.resume)
+    // コーディネーターに何らかの問題が起きている可能性がある。再接続して回復することを期待する
+    behavior = Behaviors.supervise(behavior).onFailure[OperationTimedOutException](SupervisorStrategy.restart)
+    // コネクションに問題がある。再接続して回復することを期待する
+    behavior = Behaviors.supervise(behavior).onFailure[ConnectionException](SupervisorStrategy.restart)
+    behavior = Behaviors.supervise(behavior).onFailure[Exception](SupervisorStrategy.restart)
+
+    context.spawn(
+      behavior,
       s"$sequenceId-store",
     )
+  }
 
   private def workerNameOf(sequenceSubId: Option[String]) =
     s"$sequenceId-worker${sequenceSubId.map(sub => "-" + sub).getOrElse("")}"

--- a/lerna-util-sequence/src/main/scala/lerna/util/sequence/SequenceFactorySupervisor.scala
+++ b/lerna-util-sequence/src/main/scala/lerna/util/sequence/SequenceFactorySupervisor.scala
@@ -17,7 +17,7 @@ private[sequence] object SequenceFactorySupervisor {
           maxSequenceValue = maxSequenceValue,
           reservationAmount = reservationAmount,
           context,
-        ).receive
+        ).createBehavior()
       },
     ).onFailure[Exception](SupervisorStrategy.restart)
 }
@@ -33,7 +33,7 @@ private[sequence] final class SequenceFactorySupervisor(
 
   private[this] val store = createSequenceStore()
 
-  def receive: Behaviors.Receive[SequenceFactoryWorker.GenerateSequence] =
+  def createBehavior(): Behaviors.Receive[SequenceFactoryWorker.GenerateSequence] =
     Behaviors.receiveMessage[SequenceFactoryWorker.GenerateSequence] { command =>
       val sequenceSubId = command.sequenceSubId
       val worker =

--- a/lerna-util-sequence/src/main/scala/lerna/util/sequence/SequenceFactoryWorker.scala
+++ b/lerna-util-sequence/src/main/scala/lerna/util/sequence/SequenceFactoryWorker.scala
@@ -20,7 +20,8 @@ private[sequence] object SequenceFactoryWorker extends AppTypedActorLogging {
       idleTimeout: FiniteDuration,
       sequenceSubId: Option[String],
   )(implicit tenant: Tenant): Behavior[Command] = Behaviors.setup { context =>
-    Behaviors.withStash(capacity = Int.MaxValue /* FIXME */ ) { buffer =>
+    val capacity = context.system.settings.config.getInt("lerna.util.sequence.worker.stash-capacity")
+    Behaviors.withStash(capacity) { buffer =>
       withLogger { logger =>
         new SequenceFactoryWorker(
           maxSequenceValue = maxSequenceValue,

--- a/lerna-util-sequence/src/main/scala/lerna/util/sequence/SequenceFactoryWorker.scala
+++ b/lerna-util-sequence/src/main/scala/lerna/util/sequence/SequenceFactoryWorker.scala
@@ -1,38 +1,50 @@
 package lerna.util.sequence
 
-import akka.actor.{ Actor, ActorRef, PoisonPill, Props, ReceiveTimeout, Stash }
-import lerna.log.AppActorLogging
+import akka.actor.typed
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors, StashBuffer }
+import akka.actor.typed.{ ActorRef, Behavior }
+import lerna.log.{ AppLogger, AppTypedActorLogging }
 import lerna.util.lang.Equals._
 import lerna.util.tenant.Tenant
 
 import scala.concurrent.duration.FiniteDuration
 
-private[sequence] object SequenceFactoryWorker {
+private[sequence] object SequenceFactoryWorker extends AppTypedActorLogging {
 
-  def props(
+  def apply(
       maxSequenceValue: BigInt,
       firstValue: BigInt,
       incrementStep: Int,
       reservationAmount: Int,
-      sequenceStore: ActorRef,
+      sequenceStore: ActorRef[SequenceStore.Command],
       idleTimeout: FiniteDuration,
       sequenceSubId: Option[String],
-  )(implicit tenant: Tenant): Props =
-    Props(
-      new SequenceFactoryWorker(
-        maxSequenceValue = maxSequenceValue,
-        firstValue = firstValue,
-        incrementStep = incrementStep,
-        reservationAmount = reservationAmount,
-        sequenceStore = sequenceStore,
-        idleTimeout = idleTimeout,
-        sequenceSubId = sequenceSubId,
-      ),
-    )
+  )(implicit tenant: Tenant): Behavior[Command] = Behaviors.setup { context =>
+    Behaviors.withStash(capacity = Int.MaxValue /* FIXME */ ) { buffer =>
+      withLogger { logger =>
+        new SequenceFactoryWorker(
+          maxSequenceValue = maxSequenceValue,
+          firstValue = firstValue,
+          incrementStep = incrementStep,
+          reservationAmount = reservationAmount,
+          sequenceStore = sequenceStore,
+          idleTimeout = idleTimeout,
+          sequenceSubId = sequenceSubId,
+          context,
+          buffer,
+          logger,
+        ).receive
+      }
+    }
+  }
 
   sealed trait Command
-  final case object Initialize                                            extends Command
-  final case class GenerateSequence(sequenceSubId: Option[String] = None) extends Command
+  final case object Initialize extends Command
+  final case class GenerateSequence(sequenceSubId: Option[String] = None, replyTo: typed.ActorRef[SequenceGenerated])
+      extends Command
+
+  private final case class WrappedSequenceStoreResponse(response: SequenceStore.ReservationResponse) extends Command
+  private case object ReceiveTimeout                                                                 extends Command
 
   sealed trait DomainEvent
   final case class SequenceGenerated(value: BigInt, sequenceSubId: Option[String]) extends DomainEvent
@@ -45,120 +57,153 @@ private[sequence] final class SequenceFactoryWorker(
     firstValue: BigInt,
     incrementStep: Int,
     reservationAmount: Int,
-    sequenceStore: ActorRef,
+    sequenceStore: ActorRef[SequenceStore.Command],
     idleTimeout: FiniteDuration,
     sequenceSubId: Option[String],
-)(implicit tenant: Tenant)
-    extends Actor
-    with Stash
-    with AppActorLogging {
+    context: ActorContext[SequenceFactoryWorker.Command],
+    stashBuffer: StashBuffer[SequenceFactoryWorker.Command],
+    logger: AppLogger,
+)(implicit tenant: Tenant) {
   import SequenceFactoryWorker._
 
   require(maxSequenceValue > 0 && reservationAmount > 0)
 
-  context.setReceiveTimeout(idleTimeout)
+  context.setReceiveTimeout(idleTimeout, ReceiveTimeout)
 
   import lerna.util.tenant.TenantComponentLogContext.logContext
 
   // 残りが予約したシーケンスの 1/2 以下になったら予約を開始
   private[this] val reservationFactor = 2
 
-  override def receive: Receive = notReady
-
-  override def preStart(): Unit = {
-    super.preStart()
-    self ! Initialize
+  def receive: Behaviors.Receive[Command] = {
+    context.self ! Initialize
+    notReady
   }
 
-  private[this] def notReady: Receive = {
+  private val responseMapper: ActorRef[SequenceStore.ReservationResponse] =
+    context.messageAdapter(response => WrappedSequenceStoreResponse(response))
+
+  private[this] def notReady = Behaviors.receiveMessage[Command] {
     case Initialize =>
-      sequenceStore ! SequenceStore.InitialReserveSequence(firstValue, reservationAmount, sequenceSubId)
-
-    case msg: SequenceStore.InitialSequenceReserved if msg.initialValue > maxSequenceValue =>
-      sequenceStore ! SequenceStore.ResetReserveSequence(firstValue, reservationAmount, sequenceSubId)
-      context.become(resetting)
-    case msg: SequenceStore.InitialSequenceReserved =>
-      unstashAll()
-      logger.info("initial reserved: max:{}, initial:{}", msg.maxReservedValue, msg.initialValue)
-      context.become(ready(SequenceContext(msg.maxReservedValue, nextValue = msg.initialValue)))
-    case _: GenerateSequence => stash()
+      sequenceStore ! SequenceStore.InitialReserveSequence(firstValue, reservationAmount, sequenceSubId, responseMapper)
+      Behaviors.same
+    case WrappedSequenceStoreResponse(msg: SequenceStore.InitialSequenceReserved) =>
+      if (msg.initialValue > maxSequenceValue) {
+        sequenceStore ! SequenceStore.ResetReserveSequence(firstValue, reservationAmount, sequenceSubId, responseMapper)
+        resetting
+      } else {
+        logger.info("initial reserved: max:{}, initial:{}", msg.maxReservedValue, msg.initialValue)
+        stashBuffer.unstashAll(ready(SequenceContext(msg.maxReservedValue, nextValue = msg.initialValue)))
+      }
+    case message: GenerateSequence =>
+      stashBuffer.stash(message)
+      Behaviors.same
+    case ReceiveTimeout                                                  => Behaviors.stopped
+    case WrappedSequenceStoreResponse(_: SequenceStore.SequenceReserved) => Behaviors.unhandled
+    case WrappedSequenceStoreResponse(_: SequenceStore.SequenceReset)    => Behaviors.unhandled
+    case WrappedSequenceStoreResponse(SequenceStore.ReservationFailed)   => Behaviors.unhandled // FIXME
   }
 
-  @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
-  private[this] def ready(implicit sequenceContext: SequenceContext): Receive = {
-    case msg: GenerateSequence if msg.sequenceSubId === sequenceSubId =>
-      import sequenceContext._
+  @SuppressWarnings(Array("lerna.warts.CyclomaticComplexity", "org.wartremover.warts.Recursion"))
+  private[this] def ready(implicit sequenceContext: SequenceContext): Behaviors.Receive[Command] =
+    Behaviors.receiveMessage[Command] {
+      case msg: GenerateSequence =>
+        if (msg.sequenceSubId === sequenceSubId) {
+          import sequenceContext._
 
-      if (nextValue <= maxSequenceValue) {
-        sender() ! SequenceGenerated(nextValue, sequenceSubId)
-        logger.debug("SequenceGenerated when ready: {}", nextValue)
-      } else {
-        stash()
-      }
+          if (nextValue <= maxSequenceValue) {
+            msg.replyTo ! SequenceGenerated(nextValue, sequenceSubId)
+            logger.debug("SequenceGenerated when ready: {}", nextValue)
+          } else {
+            stashBuffer.stash(msg)
+          }
 
-      val newNextValue = nextValue + incrementStep
-      val remainAmount = // 残数
-        if (maxReservedValue > newNextValue) {
-          (maxReservedValue - newNextValue) / incrementStep
-        } else BigInt(0)
+          val newNextValue = nextValue + incrementStep
+          val remainAmount = // 残数
+            if (maxReservedValue > newNextValue) {
+              (maxReservedValue - newNextValue) / incrementStep
+            } else BigInt(0)
 
-      if (newNextValue > maxSequenceValue) {
-        sequenceStore ! SequenceStore.ResetReserveSequence(firstValue, reservationAmount, sequenceSubId)
-        context.become(resetting)
-      } else if (remainAmount <= (reservationAmount / reservationFactor)) {
-        val amount = (reservationAmount - remainAmount).toInt
-        logger.info(
-          "Reserving sequence: remain {}, add {}, current max reserved: {}",
-          remainAmount,
-          amount,
-          maxReservedValue,
-        )
-        sequenceStore ! SequenceStore.ReserveSequence(maxReservedValue, amount, sequenceSubId)
-        context.become(reserving(sequenceContext.copy(nextValue = newNextValue)))
-      } else {
-        context.become(ready(sequenceContext.copy(nextValue = newNextValue)))
-      }
-  }
+          if (newNextValue > maxSequenceValue) {
+            sequenceStore ! SequenceStore.ResetReserveSequence(
+              firstValue,
+              reservationAmount,
+              sequenceSubId,
+              responseMapper,
+            )
+            resetting
+          } else if (remainAmount <= (reservationAmount / reservationFactor)) {
+            val amount = (reservationAmount - remainAmount).toInt
+            logger.info(
+              "Reserving sequence: remain {}, add {}, current max reserved: {}",
+              remainAmount,
+              amount,
+              maxReservedValue,
+            )
+            sequenceStore ! SequenceStore.ReserveSequence(maxReservedValue, amount, sequenceSubId, responseMapper)
+            reserving(sequenceContext.copy(nextValue = newNextValue))
+          } else {
+            ready(sequenceContext.copy(nextValue = newNextValue))
+          }
+        } else {
+          Behaviors.unhandled
+        }
+      case ReceiveTimeout                  => Behaviors.stopped
+      case Initialize                      => Behaviors.unhandled
+      case _: WrappedSequenceStoreResponse => Behaviors.unhandled
+    }
 
-  @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
-  private[this] def reserving(implicit sequenceContext: SequenceContext): Receive = {
-    case msg: GenerateSequence if msg.sequenceSubId === sequenceSubId =>
-      import sequenceContext._
+  @SuppressWarnings(Array("lerna.warts.CyclomaticComplexity", "org.wartremover.warts.Recursion"))
+  private[this] def reserving(implicit sequenceContext: SequenceContext): Behaviors.Receive[Command] =
+    Behaviors.receiveMessage {
+      case msg: GenerateSequence =>
+        if (msg.sequenceSubId === sequenceSubId) {
+          import sequenceContext._
 
-      if (nextValue > maxSequenceValue) {
-        stash()
-        sequenceStore ! SequenceStore.ResetReserveSequence(firstValue, reservationAmount, sequenceSubId)
-        context.become(resetting)
-      } else if (nextValue > maxReservedValue) {
-        logger.warn("Pending generate sequence because reserving sequence: {}", nextValue)
-        stash()
-      } else {
-        sender() ! SequenceGenerated(nextValue, sequenceSubId)
-        logger.debug("SequenceGenerated when reserving: {}", nextValue)
-        context.become(reserving(sequenceContext.copy(nextValue = nextValue + incrementStep)))
-      }
-    case msg: SequenceStore.SequenceReserved =>
-      unstashAll()
-      context.become(ready(sequenceContext.copy(maxReservedValue = msg.maxReservedValue)))
-    case SequenceStore.ReservationFailed =>
-      unstashAll()
-      // 即座にリトライしたところで予約できる見込みは薄いケースがあるので、
-      // クライアントから再び採番を要求されたときにリトライする方針とする
-      context.become(ready)
-  }
+          if (nextValue > maxSequenceValue) {
+            stashBuffer.stash(msg)
+            sequenceStore ! SequenceStore.ResetReserveSequence(
+              firstValue,
+              reservationAmount,
+              sequenceSubId,
+              responseMapper,
+            )
+            resetting
+          } else if (nextValue > maxReservedValue) {
+            logger.warn("Pending generate sequence because reserving sequence: {}", nextValue)
+            stashBuffer.stash(msg)
+            Behaviors.same
+          } else {
+            msg.replyTo ! SequenceGenerated(nextValue, sequenceSubId)
+            logger.debug("SequenceGenerated when reserving: {}", nextValue)
+            reserving(sequenceContext.copy(nextValue = nextValue + incrementStep))
+          }
+        } else {
+          Behaviors.unhandled
+        }
+      case WrappedSequenceStoreResponse(msg: SequenceStore.SequenceReserved) =>
+        stashBuffer.unstashAll(ready(sequenceContext.copy(maxReservedValue = msg.maxReservedValue)))
+      case WrappedSequenceStoreResponse(SequenceStore.ReservationFailed) =>
+        // 即座にリトライしたところで予約できる見込みは薄いケースがあるので、
+        // クライアントから再び採番を要求されたときにリトライする方針とする
+        stashBuffer.unstashAll(ready)
+      case ReceiveTimeout                                                         => Behaviors.stopped
+      case Initialize                                                             => Behaviors.unhandled
+      case WrappedSequenceStoreResponse(_: SequenceStore.InitialSequenceReserved) => Behaviors.unhandled
+      case WrappedSequenceStoreResponse(_: SequenceStore.SequenceReset)           => Behaviors.unhandled
+    }
 
-  private[this] def resetting: Receive = {
-    case msg: SequenceStore.SequenceReset =>
-      unstashAll()
-      context.become(ready(SequenceContext(msg.maxReservedValue, nextValue = firstValue)))
+  private[this] def resetting: Behaviors.Receive[Command] = Behaviors.receiveMessage[Command] {
+    case WrappedSequenceStoreResponse(msg: SequenceStore.SequenceReset) =>
       logger.warn("reset sequence: {}", msg.maxReservedValue)
-    case _: GenerateSequence => stash()
-  }
-
-  override def unhandled(message: Any): Unit = message match {
-    case ReceiveTimeout =>
-      self ! PoisonPill
-    case other =>
-      super.unhandled(other)
+      stashBuffer.unstashAll(ready(SequenceContext(msg.maxReservedValue, nextValue = firstValue)))
+    case message: GenerateSequence =>
+      stashBuffer.stash(message)
+      Behaviors.same
+    case ReceiveTimeout                                                         => Behaviors.stopped
+    case Initialize                                                             => Behaviors.unhandled
+    case WrappedSequenceStoreResponse(_: SequenceStore.InitialSequenceReserved) => Behaviors.unhandled
+    case WrappedSequenceStoreResponse(_: SequenceStore.SequenceReserved)        => Behaviors.unhandled
+    case WrappedSequenceStoreResponse(SequenceStore.ReservationFailed)          => Behaviors.unhandled // FIXME
   }
 }

--- a/lerna-util-sequence/src/main/scala/lerna/util/sequence/SequenceFactoryWorker.scala
+++ b/lerna-util-sequence/src/main/scala/lerna/util/sequence/SequenceFactoryWorker.scala
@@ -36,7 +36,7 @@ private[sequence] object SequenceFactoryWorker extends AppTypedActorLogging {
               context,
               buffer,
               logger,
-            ).receive
+            ).createBehavior()
           }
         }
       }
@@ -79,7 +79,7 @@ private[sequence] final class SequenceFactoryWorker(
   // 残りが予約したシーケンスの 1/2 以下になったら予約を開始
   private[this] val reservationFactor = 2
 
-  def receive: Behaviors.Receive[Command] = {
+  def createBehavior(): Behaviors.Receive[Command] = {
     context.self ! Initialize
     notReady
   }

--- a/lerna-util-sequence/src/main/scala/lerna/util/sequence/SequenceFactoryWorker.scala
+++ b/lerna-util-sequence/src/main/scala/lerna/util/sequence/SequenceFactoryWorker.scala
@@ -79,7 +79,7 @@ private[sequence] final class SequenceFactoryWorker(
   // 残りが予約したシーケンスの 1/2 以下になったら予約を開始
   private[this] val reservationFactor = 2
 
-  def createBehavior(): Behaviors.Receive[Command] = {
+  def createBehavior(): Behavior[Command] = {
     context.self ! Initialize
     notReady
   }
@@ -109,7 +109,7 @@ private[sequence] final class SequenceFactoryWorker(
   }
 
   @SuppressWarnings(Array("lerna.warts.CyclomaticComplexity", "org.wartremover.warts.Recursion"))
-  private[this] def ready(implicit sequenceContext: SequenceContext): Behaviors.Receive[Command] =
+  private[this] def ready(implicit sequenceContext: SequenceContext): Behavior[Command] =
     Behaviors.receiveMessage[Command] {
       case msg: GenerateSequence =>
         if (msg.sequenceSubId === sequenceSubId) {
@@ -158,7 +158,7 @@ private[sequence] final class SequenceFactoryWorker(
     }
 
   @SuppressWarnings(Array("lerna.warts.CyclomaticComplexity", "org.wartremover.warts.Recursion"))
-  private[this] def reserving(implicit sequenceContext: SequenceContext): Behaviors.Receive[Command] =
+  private[this] def reserving(implicit sequenceContext: SequenceContext): Behavior[Command] =
     Behaviors.receiveMessage {
       case msg: GenerateSequence =>
         if (msg.sequenceSubId === sequenceSubId) {
@@ -197,7 +197,7 @@ private[sequence] final class SequenceFactoryWorker(
       case WrappedSequenceStoreResponse(_: SequenceStore.SequenceReset)           => Behaviors.unhandled
     }
 
-  private[this] def resetting: Behaviors.Receive[Command] = Behaviors.receiveMessage[Command] {
+  private[this] def resetting: Behavior[Command] = Behaviors.receiveMessage[Command] {
     case WrappedSequenceStoreResponse(msg: SequenceStore.SequenceReset) =>
       logger.warn("reset sequence: {}", msg.maxReservedValue)
       stashBuffer.unstashAll(ready(SequenceContext(msg.maxReservedValue, nextValue = firstValue)))

--- a/lerna-util-sequence/src/main/scala/lerna/util/sequence/SequenceStore.scala
+++ b/lerna-util-sequence/src/main/scala/lerna/util/sequence/SequenceStore.scala
@@ -1,54 +1,91 @@
 package lerna.util.sequence
 
 import akka.Done
-import akka.actor.{ Actor, ActorRef, NoSerializationVerificationNeeded, Props, Stash, Status }
-import akka.pattern.pipe
+import akka.actor.NoSerializationVerificationNeeded
+import akka.actor.typed.scaladsl.{ ActorContext, Behaviors, StashBuffer }
+import akka.actor.typed._
 import com.datastax.driver.core._
-import lerna.log.AppActorLogging
+import lerna.log.{ AppLogger, AppTypedActorLogging }
+import lerna.util.lang.Equals._
 import lerna.util.sequence.FutureConverters.ListenableFutureConverter
 import lerna.util.tenant.Tenant
 
-import scala.jdk.CollectionConverters._
 import scala.concurrent.Future
+import scala.jdk.CollectionConverters._
+import scala.util.{ Failure, Success }
 
-private[sequence] object SequenceStore {
+private[sequence] object SequenceStore extends AppTypedActorLogging {
 
-  def props(sequenceId: String, nodeId: Int, incrementStep: BigInt, config: SequenceFactoryCassandraConfig)(implicit
+  def apply(sequenceId: String, nodeId: Int, incrementStep: BigInt, config: SequenceFactoryCassandraConfig)(implicit
       tenant: Tenant,
-  ): Props =
-    Props(new SequenceStore(sequenceId = sequenceId, nodeId = nodeId, incrementStep = incrementStep, config = config))
+  ): Behavior[Command] = Behaviors.setup { context =>
+    Behaviors.withStash(capacity = Int.MaxValue /* FIXME */ ) { buffer =>
+      withLogger { logger =>
+        new SequenceStore(
+          sequenceId = sequenceId,
+          nodeId = nodeId,
+          incrementStep = incrementStep,
+          config = config,
+          context,
+          buffer,
+          logger,
+        ).receive
+      }
+    }
+  }
 
   sealed trait Command            extends NoSerializationVerificationNeeded
   private case object OpenSession extends Command
-  final case class InitialReserveSequence(firstValue: BigInt, reservationAmount: Int, sequenceSubId: Option[String])
-      extends Command {
+  final case class InitialReserveSequence(
+      firstValue: BigInt,
+      reservationAmount: Int,
+      sequenceSubId: Option[String],
+      replyTo: ActorRef[ReservationResponse],
+  ) extends Command {
     require(firstValue > 0 && reservationAmount > 0)
   }
-  final case class ReserveSequence(maxReservedValue: BigInt, reservationAmount: Int, sequenceSubId: Option[String])
-      extends Command {
+  final case class ReserveSequence(
+      maxReservedValue: BigInt,
+      reservationAmount: Int,
+      sequenceSubId: Option[String],
+      replyTo: ActorRef[ReservationResponse],
+  ) extends Command {
     require(maxReservedValue > 0 && reservationAmount > 0)
   }
-  final case class ResetReserveSequence(firstValue: BigInt, reservationAmount: Int, sequenceSubId: Option[String])
-      extends Command {
+  final case class ResetReserveSequence(
+      firstValue: BigInt,
+      reservationAmount: Int,
+      sequenceSubId: Option[String],
+      replyTo: ActorRef[ReservationResponse],
+  ) extends Command {
     require(firstValue > 0 && reservationAmount > 0)
   }
 
-  sealed trait DomainEvent                                                 extends NoSerializationVerificationNeeded
-  private final case class SessionOpened(session: Session)                 extends DomainEvent
-  private final case class SessionPrepared(sessionContext: SessionContext) extends DomainEvent
+  sealed trait SessionResult                                               extends Command
+  private final case class SessionOpened(session: Session)                 extends SessionResult
+  private final case class SessionPrepared(sessionContext: SessionContext) extends SessionResult
+  private final case class SessionFailed(exception: Throwable)             extends SessionResult
+
+  sealed trait ReservationResponse       extends NoSerializationVerificationNeeded
+  sealed trait InternalReservationResult extends Command
   final case class InitialSequenceReserved(
       initialValue: BigInt,
       maxReservedValue: BigInt,
-  ) extends DomainEvent {
+  ) extends InternalReservationResult
+      with ReservationResponse {
     require(initialValue >= 0 && maxReservedValue > 0)
   }
-  final case class SequenceReserved(maxReservedValue: BigInt) extends DomainEvent {
+  final case class SequenceReserved(maxReservedValue: BigInt)
+      extends InternalReservationResult
+      with ReservationResponse {
     require(maxReservedValue > 0)
   }
-  final case class SequenceReset(maxReservedValue: BigInt) extends DomainEvent {
+  final case class SequenceReset(maxReservedValue: BigInt) extends InternalReservationResult with ReservationResponse {
     require(maxReservedValue > 0)
   }
-  final case object ReservationFailed extends RuntimeException with DomainEvent
+  private final case class InternalReservationFailed(exception: Throwable) extends InternalReservationResult
+
+  final case object ReservationFailed extends RuntimeException with ReservationResponse
 
   private final case class SessionContext(
       session: Session,
@@ -62,88 +99,113 @@ private[sequence] final class SequenceStore(
     nodeId: Int,
     incrementStep: BigInt,
     config: SequenceFactoryCassandraConfig,
-)(implicit tenant: Tenant)
-    extends Actor
-    with Stash
-    with AppActorLogging {
+    context: ActorContext[SequenceStore.Command],
+    stashBuffer: StashBuffer[SequenceStore.Command],
+    logger: AppLogger,
+)(implicit tenant: Tenant) {
   require(nodeId > 0)
 
   import SequenceStore._
-  import context.dispatcher
+  import context.executionContext
   import lerna.util.tenant.TenantComponentLogContext.logContext
 
   val statements = new CassandraStatements(config)
 
-  override def receive: Receive = notReady
-
-  override def preStart(): Unit = {
-    super.preStart()
-    self ! OpenSession
+  def receive: Behaviors.Receive[Command] = {
+    context.self ! OpenSession
+    notReady
   }
 
-  // Actor の状態を意識しながら Session を扱いたいので、Session の乱用を防ぐため、
-  // Session を直接配置せずに Session を close するだけの関数を配置
-  @SuppressWarnings(Array("org.wartremover.warts.Var"))
-  private[this] var sessionCloser: Option[() => Unit] = None
-
-  override def postStop(): Unit = {
-    sessionCloser.foreach(_.apply())
-    super.postStop()
+  private def close(session: Session): PartialFunction[(ActorContext[Command], Signal), Behavior[Command]] = {
+    case (_, signal) if signal === PreRestart || signal === PostStop =>
+      session.close()
+      Behaviors.same
   }
 
-  private[this] def notReady: Receive = {
-    case OpenSession               => openSession() pipeTo self
-    case _: InitialReserveSequence => stash()
-    case _: ReserveSequence        => stash()
+  @SuppressWarnings(Array("lerna.warts.CyclomaticComplexity", "org.wartremover.warts.Recursion"))
+  private[this] def notReady: Behaviors.Receive[Command] = Behaviors.receiveMessage {
+    case OpenSession =>
+      context.pipeToSelf(openSession()) {
+        case Success(sessionOpened) => sessionOpened
+        case Failure(exception)     => SessionFailed(exception)
+      }
+      Behaviors.same
+    case message: InitialReserveSequence =>
+      stashBuffer.stash(message)
+      Behaviors.same
+    case message: ReserveSequence =>
+      stashBuffer.stash(message)
+      Behaviors.same
+    case message: ResetReserveSequence =>
+      stashBuffer.stash(message)
+      Behaviors.same
     case SessionOpened(session) =>
-      sessionCloser = Option(() => session.close())
-      prepareSession(session) pipeTo self
+      context.pipeToSelf(prepareSession(session)) {
+        case Success(sessionPrepared) => sessionPrepared
+        case Failure(exception)       => SessionFailed(exception)
+      }
+      notReady.receiveSignal(close(session))
     case SessionPrepared(sessionContext) =>
-      unstashAll()
       logger.info("Cassandra session was ready (sequenceId: {}, nodeId: {})", sequenceId, nodeId)
-      context.become(ready(sessionContext))
+      stashBuffer.unstashAll(ready(sessionContext))
+
+    case SessionFailed(throwable)     => throw throwable
+    case _: InternalReservationResult => Behaviors.unhandled
   }
 
-  private[this] def ready(implicit sessionContext: SessionContext): Receive = {
-    case InitialReserveSequence(firstValue, reservationAmount, sequenceSubId) =>
-      initialReserve(firstValue, reservationAmount, sequenceSubId) pipeTo self
-      context.become(reserving(replyTo = sender()))
-    case ReserveSequence(maxReservationValue, reservationAmount, sequenceSubId) =>
-      reserve(maxReservationValue, reservationAmount, sequenceSubId) pipeTo self
-      context.become(reserving(replyTo = sender()))
-    case ResetReserveSequence(firstValue, reservationAmount, sequenceSubId) =>
-      reset(firstValue, reservationAmount, sequenceSubId) pipeTo self
-      context.become(reserving(replyTo = sender()))
-  }
+  @SuppressWarnings(Array("lerna.warts.CyclomaticComplexity"))
+  private[this] def ready(implicit sessionContext: SessionContext): Behavior[Command] = Behaviors
+    .receiveMessage[Command] {
+      case InitialReserveSequence(firstValue, reservationAmount, sequenceSubId, replyTo) =>
+        context.pipeToSelf(initialReserve(firstValue, reservationAmount, sequenceSubId)) {
+          case Success(initialSequenceReserved) => initialSequenceReserved
+          case Failure(exception)               => InternalReservationFailed(exception)
+        }
+        reserving(replyTo = replyTo)
+      case ReserveSequence(maxReservationValue, reservationAmount, sequenceSubId, replyTo) =>
+        context.pipeToSelf(reserve(maxReservationValue, reservationAmount, sequenceSubId)) {
+          case Success(sequenceReserved) => sequenceReserved
+          case Failure(exception)        => InternalReservationFailed(exception)
+        }
+        reserving(replyTo = replyTo)
+      case ResetReserveSequence(firstValue, reservationAmount, sequenceSubId, replyTo) =>
+        context.pipeToSelf(reset(firstValue, reservationAmount, sequenceSubId)) {
+          case Success(sequenceReset) => sequenceReset
+          case Failure(exception)     => InternalReservationFailed(exception)
+        }
+        reserving(replyTo = replyTo)
+      case OpenSession                  => Behaviors.unhandled
+      case _: SessionResult             => Behaviors.unhandled
+      case _: InternalReservationResult => Behaviors.unhandled
+    }.receiveSignal(close(sessionContext.session))
 
-  private[this] def reserving(replyTo: ActorRef)(implicit sessionContext: SessionContext): Receive = {
-    case _: InitialReserveSequence =>
-      stash()
-    case _: ReserveSequence =>
-      stash()
-    case _: ResetReserveSequence =>
-      stash()
-    case event: InitialSequenceReserved =>
-      replyTo ! event
-      unstashAll()
-      context.become(ready)
-    case event: SequenceReserved =>
-      replyTo ! event
-      unstashAll()
-      context.become(ready)
-    case event: SequenceReset =>
-      replyTo ! event
-      unstashAll()
-      context.become(ready)
-    case Status.Failure(ex) =>
-      replyTo ! ReservationFailed
-      throw ex
-  }
-
-  override def unhandled(message: Any): Unit = message match {
-    case Status.Failure(ex) => throw ex
-    case other              => super.unhandled(other)
-  }
+  private[this] def reserving(replyTo: ActorRef[ReservationResponse])(implicit sessionContext: SessionContext) =
+    Behaviors
+      .receiveMessage[Command] {
+        case message: InitialReserveSequence =>
+          stashBuffer.stash(message)
+          Behaviors.same
+        case message: ReserveSequence =>
+          stashBuffer.stash(message)
+          Behaviors.same
+        case message: ResetReserveSequence =>
+          stashBuffer.stash(message)
+          Behaviors.same
+        case event: InitialSequenceReserved =>
+          replyTo ! event
+          stashBuffer.unstashAll(ready)
+        case event: SequenceReserved =>
+          replyTo ! event
+          stashBuffer.unstashAll(ready)
+        case event: SequenceReset =>
+          replyTo ! event
+          stashBuffer.unstashAll(ready)
+        case InternalReservationFailed(exception) =>
+          replyTo ! ReservationFailed
+          throw exception
+        case OpenSession      => Behaviors.unhandled
+        case _: SessionResult => Behaviors.unhandled
+      }.receiveSignal(close(sessionContext.session))
 
   private[this] def openSession(): Future[SessionOpened] = {
     val sessionFuture = config

--- a/lerna-util-sequence/src/main/scala/lerna/util/sequence/SequenceStore.scala
+++ b/lerna-util-sequence/src/main/scala/lerna/util/sequence/SequenceStore.scala
@@ -131,7 +131,7 @@ private[sequence] final class SequenceStore(
 
   val statements = new CassandraStatements(config)
 
-  def createBehavior(): Behaviors.Receive[Command] = {
+  def createBehavior(): Behavior[Command] = {
     context.self ! OpenSession
     notReady
   }

--- a/lerna-util-sequence/src/main/scala/lerna/util/sequence/SequenceStore.scala
+++ b/lerna-util-sequence/src/main/scala/lerna/util/sequence/SequenceStore.scala
@@ -33,7 +33,7 @@ private[sequence] object SequenceStore extends AppTypedActorLogging {
             context,
             buffer,
             logger,
-          ).receive
+          ).createBehavior()
         }
       }
     }
@@ -131,7 +131,7 @@ private[sequence] final class SequenceStore(
 
   val statements = new CassandraStatements(config)
 
-  def receive: Behaviors.Receive[Command] = {
+  def createBehavior(): Behaviors.Receive[Command] = {
     context.self ! OpenSession
     notReady
   }

--- a/lerna-util-sequence/src/main/scala/lerna/util/sequence/SequenceStore.scala
+++ b/lerna-util-sequence/src/main/scala/lerna/util/sequence/SequenceStore.scala
@@ -19,7 +19,8 @@ private[sequence] object SequenceStore extends AppTypedActorLogging {
   def apply(sequenceId: String, nodeId: Int, incrementStep: BigInt, config: SequenceFactoryCassandraConfig)(implicit
       tenant: Tenant,
   ): Behavior[Command] = Behaviors.setup { context =>
-    Behaviors.withStash(capacity = Int.MaxValue /* FIXME */ ) { buffer =>
+    val capacity = context.system.settings.config.getInt("lerna.util.sequence.store.stash-capacity")
+    Behaviors.withStash(capacity) { buffer =>
       withLogger { logger =>
         new SequenceStore(
           sequenceId = sequenceId,

--- a/lerna-util-sequence/src/test/scala/lerna/util/sequence/SequenceFactoryWorkerSpec.scala
+++ b/lerna-util-sequence/src/test/scala/lerna/util/sequence/SequenceFactoryWorkerSpec.scala
@@ -1,9 +1,10 @@
 package lerna.util.sequence
 
-import akka.actor.{ ActorSystem, PoisonPill }
-import akka.testkit.TestProbe
 import com.typesafe.config.ConfigFactory
+import lerna.testkit.akka.ScalaTestWithTypedActorTestKit
+import lerna.tests.LernaBaseSpec
 import lerna.util.tenant.Tenant
+import org.scalatest.Inside
 
 import scala.concurrent.duration._
 
@@ -17,7 +18,9 @@ object SequenceFactoryWorkerSpec {
 }
 
 class SequenceFactoryWorkerSpec
-    extends LernaSequenceActorBaseSpec(ActorSystem("SequenceFactoryWorkerSpec", SequenceFactoryWorkerSpec.config)) {
+    extends ScalaTestWithTypedActorTestKit(SequenceFactoryWorkerSpec.config)
+    with LernaBaseSpec
+    with Inside {
 
   private implicit val tenant: Tenant = new Tenant {
     override def id: String = "dummy"
@@ -28,57 +31,77 @@ class SequenceFactoryWorkerSpec
   "SequenceFactoryWorker" should {
 
     "採番の初項は firstValue で指定できる" in {
-      val storeProbe = TestProbe()
-      val worker = system.actorOf(
+      val storeProbe = createTestProbe[SequenceStore.Command]()
+      val worker = spawn(
         SequenceFactoryWorker
-          .props(
+          .apply(
             maxSequenceValue = 999,
             firstValue = 3,
             incrementStep = 10,
             reservationAmount = 11,
-            storeProbe.testActor,
+            storeProbe.ref,
             idleTimeout = 10.seconds,
             sequenceSubId,
           ),
       )
       // reservationAmount の個数だけ採番できるように予約
-      storeProbe.expectMsg(SequenceStore.InitialReserveSequence(firstValue = 3, reservationAmount = 11, sequenceSubId))
-      storeProbe.reply(SequenceStore.InitialSequenceReserved(initialValue = 3, maxReservedValue = 113))
+      val replyTo = inside(storeProbe.receiveMessage()) {
+        case result: SequenceStore.InitialReserveSequence =>
+          expect(result.firstValue === BigInt(3))
+          expect(result.reservationAmount === 11)
+          expect(result.sequenceSubId === sequenceSubId)
+          result.replyTo
+      }
+      replyTo ! SequenceStore.InitialSequenceReserved(initialValue = 3, maxReservedValue = 113)
 
-      worker ! SequenceFactoryWorker.GenerateSequence(sequenceSubId)
-      expectMsg(SequenceFactoryWorker.SequenceGenerated(3, sequenceSubId))
+      val replyToProbe = createTestProbe[SequenceFactoryWorker.SequenceGenerated]()
+      worker ! SequenceFactoryWorker.GenerateSequence(sequenceSubId, replyToProbe.ref)
+      replyToProbe.expectMessage(SequenceFactoryWorker.SequenceGenerated(3, sequenceSubId))
 
-      worker ! PoisonPill
+      testKit.stop(worker)
     }
 
     "予約した採番値が枯渇した場合は新たに予約して採番する" in {
-      val storeProbe = TestProbe()
-      val worker = system.actorOf(
+      val storeProbe = createTestProbe[SequenceStore.Command]()
+      val worker = spawn(
         SequenceFactoryWorker
-          .props(
+          .apply(
             maxSequenceValue = 999,
             firstValue = 3,
             incrementStep = 10,
             reservationAmount = 1,
-            storeProbe.testActor,
+            storeProbe.ref,
             idleTimeout = 10.seconds,
             sequenceSubId,
           ),
       )
-      storeProbe.expectMsg(SequenceStore.InitialReserveSequence(firstValue = 3, reservationAmount = 1, sequenceSubId))
-      storeProbe.reply(SequenceStore.InitialSequenceReserved(initialValue = 3, maxReservedValue = 3))
+      val replyTo1 = inside(storeProbe.receiveMessage()) {
+        case result: SequenceStore.InitialReserveSequence =>
+          expect(result.firstValue === BigInt(3))
+          expect(result.reservationAmount === 1)
+          expect(result.sequenceSubId === sequenceSubId)
+          result.replyTo
+      }
+      replyTo1 ! SequenceStore.InitialSequenceReserved(initialValue = 3, maxReservedValue = 3)
 
+      val replyToProbe = createTestProbe[SequenceFactoryWorker.SequenceGenerated]()
       // reservationAmount が 1 なので、1回採番すると枯渇
-      worker ! SequenceFactoryWorker.GenerateSequence(sequenceSubId)
-      expectMsg(SequenceFactoryWorker.SequenceGenerated(3, sequenceSubId))
+      worker ! SequenceFactoryWorker.GenerateSequence(sequenceSubId, replyToProbe.ref)
+      replyToProbe.expectMessage(SequenceFactoryWorker.SequenceGenerated(3, sequenceSubId))
 
       // 枯渇した場合は新たな採番値を予約して採番
-      worker ! SequenceFactoryWorker.GenerateSequence(sequenceSubId)
-      storeProbe.expectMsg(SequenceStore.ReserveSequence(maxReservedValue = 3, reservationAmount = 1, sequenceSubId))
-      storeProbe.reply(SequenceStore.SequenceReserved(maxReservedValue = 13))
-      expectMsg(SequenceFactoryWorker.SequenceGenerated(13, sequenceSubId))
+      worker ! SequenceFactoryWorker.GenerateSequence(sequenceSubId, replyToProbe.ref)
+      val replyTo2 = inside(storeProbe.receiveMessage()) {
+        case result: SequenceStore.ReserveSequence =>
+          expect(result.maxReservedValue === BigInt(3))
+          expect(result.reservationAmount === 1)
+          expect(result.sequenceSubId === sequenceSubId)
+          result.replyTo
+      }
+      replyTo2 ! SequenceStore.SequenceReserved(maxReservedValue = 13)
+      replyToProbe.expectMessage(SequenceFactoryWorker.SequenceGenerated(13, sequenceSubId))
 
-      worker ! PoisonPill
+      testKit.stop(worker)
     }
   }
 


### PR DESCRIPTION
https://github.com/lerna-stack/lerna-app-library/issues/11 ```v2.0.0 · Issue #11 · lerna-stack/lerna-app-library```

> Akka Classic 向けに提供している機能を Akka Typed 向けにも提供します

## 変更内容
- trait ` val system: ActorSystem` -> `val system: ClassicActorSystemProvider`
- インスタンス化test追加
- typed 化 (typed ActorSystem を使用すると actor を作成できない問題に対処)

## 参考
- [Stash • Akka Documentation](https://doc.akka.io/docs/akka/current/typed/stash.html)
  - `Behaviors.withStash()`
- [Interaction Patterns • Akka Documentation](https://doc.akka.io/docs/akka/current/typed/interaction-patterns.html#adapted-response)
  - `context.messageAdapter`
- [Fault Tolerance • Akka Documentation](https://doc.akka.io/docs/akka/current/typed/fault-tolerance.html#supervision)
  - `copysourceBehaviors.supervise(behavior).onFailure[type](???)`

## 関連する問題
https://github.com/lerna-stack/lerna-app-library/issues/24 ```typed ActorSystem を new して使うと一部モジュールでエラー · Issue #24 · lerna-stack/lerna-app-library```

- クラシック Props を typed API (Behavior) に書き換える

を選択した。

Extension化は テナント情報 `def supportedTenants: Seq[Tenant]` をコンストラクタに渡すことができないため、不可

## このPRで修正しない既存の改善点/問題
- SequenceFactoryWorker
  - `Initialize` が不要
  - `SequenceStore.ReservationFailed` の handling 漏れ
  - `Command` は `NoSerializationVerificationNeeded` を継承したほうが良い
- SequenceStore
  - `OpenSession` が不要
  - `final case object ReservationFailed extends RuntimeException` の `RuntimeException` が不要

Issue にしました。
https://github.com/lerna-stack/lerna-app-library/issues/35 ```lerna-util-sequence 改善 · Issue #35 · lerna-stack/lerna-app-library```