### PR TITLE
feat: lerna-http の typed 対応

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -373,8 +373,8 @@ lazy val lernaHTTP = lernaModule("lerna-http")
       Dependencies.Akka.stream,
       Dependencies.AkkaHTTP.http,
       Dependencies.AkkaHTTP.sprayJson,
-      Dependencies.Akka.testKit         % Test,
-      Dependencies.AkkaHTTP.httpTestKit % Test,
+      Dependencies.Akka.actorTestKitTyped % Test,
+      Dependencies.AkkaHTTP.httpTestKit   % Test,
     ),
   )
 

--- a/lerna-http/src/main/mima-filters/1.0.0.backwards.excludes/31-typed-support.backwards.excludes
+++ b/lerna-http/src/main/mima-filters/1.0.0.backwards.excludes/31-typed-support.backwards.excludes
@@ -1,0 +1,8 @@
+# typed ActorSystem 対応
+# ClassicActorSystemProvider は typed/classic 両方の ActorSystem が継承しているので compileエラーにはならない
+# ※ Akka 2.6 以上のみ対応
+
+# abstract method system()akka.actor.ActorSystem in interface lerna.http.HttpRequestProxySupport has a different result type in current version, where it is akka.actor.ClassicActorSystemProvider rather than akka.actor.ActorSystem
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("lerna.http.HttpRequestProxySupport.system")
+# abstract method system()akka.actor.ClassicActorSystemProvider in interface lerna.http.HttpRequestProxySupport is present only in current version
+ProblemFilters.exclude[ReversedMissingMethodProblem]("lerna.http.HttpRequestProxySupport.system")

--- a/lerna-http/src/main/scala/lerna/http/HttpRequestLoggingSupport.scala
+++ b/lerna-http/src/main/scala/lerna/http/HttpRequestLoggingSupport.scala
@@ -15,7 +15,7 @@ import scala.util.{ Failure, Success }
   */
 trait HttpRequestLoggingSupport extends HttpRequestProxySupport { self: AppLogging =>
 
-  implicit val system: ClassicActorSystemProvider
+  val system: ClassicActorSystemProvider
   implicit private def classicSystem: ActorSystem         = system.classicSystem
   private[this] implicit def ec: ExecutionContextExecutor = classicSystem.dispatcher
 

--- a/lerna-http/src/main/scala/lerna/http/HttpRequestProxySupport.scala
+++ b/lerna-http/src/main/scala/lerna/http/HttpRequestProxySupport.scala
@@ -2,7 +2,7 @@ package lerna.http
 
 import java.net.InetSocketAddress
 
-import akka.actor.ActorSystem
+import akka.actor.ClassicActorSystemProvider
 import akka.http.scaladsl.ClientTransport
 import akka.http.scaladsl.model.headers
 import akka.http.scaladsl.settings.{ ClientConnectionSettings, ConnectionPoolSettings }
@@ -17,11 +17,11 @@ trait HttpRequestProxySupport {
 
   /** The [[akka.actor.ActorSystem]] that is used for extracting settings.
     */
-  val system: ActorSystem
+  val system: ClassicActorSystemProvider
 
-  private val baseConnectionPoolSettings = ConnectionPoolSettings(system)
+  private val baseConnectionPoolSettings = ConnectionPoolSettings(system.classicSystem)
 
-  private val tenantsConfig                        = system.settings.config.getConfig("lerna.http.proxy.tenants")
+  private val tenantsConfig                        = system.classicSystem.settings.config.getConfig("lerna.http.proxy.tenants")
   private def proxyConfig(implicit tenant: Tenant) = tenantsConfig.getConfig(s"${tenant.id}")
 
   private def host(implicit tenant: Tenant) = proxyConfig.getString("host")
@@ -43,7 +43,7 @@ trait HttpRequestProxySupport {
     */
   protected def generateRequestSetting(useProxy: Boolean)(implicit tenant: Tenant): ConnectionPoolSettings = {
     if (useProxy) {
-      val clientConnectionSettings = ClientConnectionSettings(system).withTransport(httpsProxyTransport)
+      val clientConnectionSettings = ClientConnectionSettings(system.classicSystem).withTransport(httpsProxyTransport)
       baseConnectionPoolSettings.withConnectionSettings(clientConnectionSettings)
     } else {
       baseConnectionPoolSettings

--- a/lerna-http/src/test/scala/lerna/http/HttpRequestLoggingSupportSpec.scala
+++ b/lerna-http/src/test/scala/lerna/http/HttpRequestLoggingSupportSpec.scala
@@ -1,6 +1,6 @@
 package lerna.http
 
-import akka.actor.ActorSystem
+import akka.actor.{ typed, ActorSystem }
 import lerna.log.AppLogging
 import lerna.testkit.akka.ScalaTestWithTypedActorTestKit
 import lerna.tests.LernaBaseSpec
@@ -8,6 +8,13 @@ import lerna.tests.LernaBaseSpec
 private object HttpRequestLoggingSupportSpec {
   class HttpRequestLoggingSupportForClassic(
       val system: ActorSystem,
+  ) extends HttpRequestLoggingSupport
+      with AppLogging {
+    override val scope: String = "dummy"
+  }
+
+  class HttpRequestLoggingSupportForTyped(
+      val system: typed.ActorSystem[_],
   ) extends HttpRequestLoggingSupport
       with AppLogging {
     override val scope: String = "dummy"
@@ -21,6 +28,11 @@ class HttpRequestLoggingSupportSpec extends ScalaTestWithTypedActorTestKit() wit
     "Classic ActorSystem を使ってインスタンス化できる" in {
       val classicSystem: ActorSystem = system.classicSystem
       noException should be thrownBy new HttpRequestLoggingSupportForClassic(classicSystem)
+    }
+
+    "Typed ActorSystem を使ってインスタンス化できる" in {
+      val typedSystem: typed.ActorSystem[_] = system
+      noException should be thrownBy new HttpRequestLoggingSupportForTyped(typedSystem)
     }
   }
 }

--- a/lerna-http/src/test/scala/lerna/http/HttpRequestLoggingSupportSpec.scala
+++ b/lerna-http/src/test/scala/lerna/http/HttpRequestLoggingSupportSpec.scala
@@ -1,0 +1,26 @@
+package lerna.http
+
+import akka.actor.ActorSystem
+import lerna.log.AppLogging
+import lerna.testkit.akka.ScalaTestWithTypedActorTestKit
+import lerna.tests.LernaBaseSpec
+
+private object HttpRequestLoggingSupportSpec {
+  class HttpRequestLoggingSupportForClassic(
+      val system: ActorSystem,
+  ) extends HttpRequestLoggingSupport
+      with AppLogging {
+    override val scope: String = "dummy"
+  }
+}
+
+class HttpRequestLoggingSupportSpec extends ScalaTestWithTypedActorTestKit() with LernaBaseSpec {
+  import HttpRequestLoggingSupportSpec._
+
+  "HttpRequestLoggingSupport" should {
+    "Classic ActorSystem を使ってインスタンス化できる" in {
+      val classicSystem: ActorSystem = system.classicSystem
+      noException should be thrownBy new HttpRequestLoggingSupportForClassic(classicSystem)
+    }
+  }
+}


### PR DESCRIPTION
`val system: ActorSystem`
↓
`val system: ClassicActorSystemProvider`
に変更。

[ClassicActorSystemProvider](https://doc.akka.io/japi/akka/current/akka/actor/ClassicActorSystemProvider.html) は typed/classic 両方の ActorSystem が継承しているので compileエラーにはならない