### PR TITLE
fix: 特定の状況で lerna.management.stats.Metrics の apply で compile エラーになる問題に対応

### DIFF
--- a/lerna-management/src/main/mima-filters/1.0.0.backwards.excludes/32-typed-support-fix-compile-error.backwards.excludes
+++ b/lerna-management/src/main/mima-filters/1.0.0.backwards.excludes/32-typed-support-fix-compile-error.backwards.excludes
@@ -1,0 +1,15 @@
+# typed ActorSystem 対応
+# ClassicActorSystemProvider は typed/classic 両方の ActorSystem が継承しているので compileエラーにはならない
+# ※ Akka 2.6 以上のみ対応
+
+# akka.actor.ActorSystem を使っている状況で、 Tenant を継承した別の trait 型(例: AppTenant)を使用していると Set[AppTenant] が 自動で Set[Tenant] にならず、コンパイルエラーになる
+# 型を明示することで回避可能だが、 lib 側の akka.actor.ActorSystem を受け取る apply method を削除すると楽になるため ActorSystem を受け取る apply method を削除
+# [error]      overloaded method value apply with alternatives:
+# [error]        (system: akka.actor.ClassicActorSystemProvider,tenants: Set[lerna.util.tenant.Tenant])lerna.management.stats.Metrics <and>
+# [error]        (system: akka.actor.ActorSystem,tenants: Set[lerna.util.tenant.Tenant])lerna.management.stats.Metrics
+
+
+# static method apply(akka.actor.ActorSystem,scala.collection.immutable.Set)lerna.management.stats.Metrics in interface lerna.management.stats.Metrics's type is different in current version, where it is (akka.actor.ClassicActorSystemProvider,scala.collection.immutable.Set)lerna.management.stats.Metrics instead of (akka.actor.ActorSystem,scala.collection.immutable.Set)lerna.management.stats.Metrics
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("lerna.management.stats.Metrics.apply")
+# method apply(akka.actor.ActorSystem,scala.collection.immutable.Set)lerna.management.stats.Metrics in object lerna.management.stats.Metrics's type is different in current version, where it is (akka.actor.ClassicActorSystemProvider,scala.collection.immutable.Set)lerna.management.stats.Metrics instead of (akka.actor.ActorSystem,scala.collection.immutable.Set)lerna.management.stats.Metrics
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("lerna.management.stats.Metrics.apply")

--- a/lerna-management/src/main/scala/lerna/management/stats/Metrics.scala
+++ b/lerna-management/src/main/scala/lerna/management/stats/Metrics.scala
@@ -1,6 +1,6 @@
 package lerna.management.stats
 
-import akka.actor.{ ActorSystem, ClassicActorSystemProvider }
+import akka.actor.ClassicActorSystemProvider
 import kamon.module.MetricReporter
 import lerna.log.AppLogging
 import lerna.util.tenant.Tenant
@@ -33,11 +33,7 @@ object Metrics {
     * @param tenants Set of supporting tenants
     * @return The instance of [[Metrics]]
     */
-  def apply(system: ActorSystem, tenants: Set[Tenant]): Metrics = {
-    new MetricsImpl(system, tenants)
-  }
-
   def apply(system: ClassicActorSystemProvider, tenants: Set[Tenant]): Metrics = {
-    apply(system.classicSystem, tenants)
+    new MetricsImpl(system.classicSystem, tenants)
   }
 }


### PR DESCRIPTION
akka.actor.ActorSystem を使っている状況で、 Tenant を継承した別の trait 型(例: AppTenant)を使用していると Set[AppTenant] が 自動で Set[Tenant] にならず、コンパイルエラーになる 
(型推論できない)


型を明示することで回避可能だが、 lib 側の akka.actor.ActorSystem を受け取る apply method を削除すると楽になるため ActorSystem を受け取る apply method を削除
(method を削除しても残りの ClassicActorSystemProvider を受け取る apply method が使用可能)

別リポジトリのコード&エラー例
[lerna-sample-payment-app/ApplicationDIDesign.scala at v1.1.0 · lerna-stack/lerna-sample-payment-app](https://github.com/lerna-stack/lerna-sample-payment-app/blob/v1.1.0/payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/ApplicationDIDesign.scala)

```
[error] [E1] payment-app\application\src\main\scala\jp\co\tis\lerna\payment\application\ApplicationDIDesign.scala
[error]      overloaded method value apply with alternatives:
[error]        (system: akka.actor.ClassicActorSystemProvider,tenants: Set[lerna.util.tenant.Tenant])lerna.management.stats.Metrics <and>
[error]        (system: akka.actor.ActorSystem,tenants: Set[lerna.util.tenant.Tenant])lerna.management.stats.Metrics
[error]       cannot be applied to (akka.actor.ActorSystem, scala.collection.immutable.Set[jp.co.tis.lerna.payment.utility.tenant.AppTenant])
[error]      L36:       Metrics(system, AppTenant.values.toSet)
[error]                 ^
```

## 関連
- https://github.com/lerna-stack/lerna-app-library/pull/25 ```lerna-management: Typed 対応 by tksugimoto · Pull Request #25 · lerna-stack/lerna-app-library```