### PR TITLE
Update akka-http to 10.2.4

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
     val accord                = "0.7.6"
     val airframe              = "20.9.0"
     val akka                  = "2.6.8"
-    val akkaHTTP              = "10.1.12"
+    val akkaHTTP              = "10.2.4"
     val cassandraDriverCore   = "3.7.1"
     val kamonCore             = "2.1.18"
     val kamonSystemMetrics    = "2.1.18"


### PR DESCRIPTION
- [10.2.x Release Notes • Akka HTTP](https://doc.akka.io/docs/akka-http/current/release-notes/10.2.x.html)
- [Migration Guide to and within Akka HTTP 10.2.x • Akka HTTP](https://doc.akka.io/docs/akka-http/current/migration-guide/migration-guide-10.2.x.html)

## 関連
- https://github.com/lerna-stack/lerna-sample-payment-app/pull/27 ```Update akka http 10.2 by tksugimoto · Pull Request #27 · lerna-stack/lerna-sample-payment-app```

## 動作確認
- `start-app-1.sh`, `start-app-2.sh` を使用して curl でリクエストが通った
- route 中で `throw` して 対応した HTTP ステータスコードが帰ってきた (デフォルトは 500)