### PR TITLE
Fix/lerna-http/log出力修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 [Unreleased]: https://github.com/lerna-stack/lerna-app-library/compare/v1.0.0...main
 
+### Fixed
+- `lerna-http`
+    - Fixed an issue where HTTP Body was not logged
+    - Fixed an issue where URL queries were not logged
+
 ### Added
 - `lerna-testkit`: Added testkit for TypedActor
 - `lerna-log`: Added Logger for TypedActor

--- a/build.sbt
+++ b/build.sbt
@@ -375,6 +375,7 @@ lazy val lernaHTTP = lernaModule("lerna-http")
       Dependencies.AkkaHTTP.sprayJson,
       Dependencies.Akka.actorTestKitTyped % Test,
       Dependencies.AkkaHTTP.httpTestKit   % Test,
+      Dependencies.Logback.classic        % Test,
     ),
   )
 

--- a/lerna-http/src/main/scala/lerna/http/HttpRequestLoggingSupport.scala
+++ b/lerna-http/src/main/scala/lerna/http/HttpRequestLoggingSupport.scala
@@ -3,6 +3,7 @@ package lerna.http
 import akka.actor.{ ActorSystem, ClassicActorSystemProvider }
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
+import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.pattern.after
 import lerna.log.AppLogging
 import lerna.util.trace.RequestContext
@@ -47,9 +48,15 @@ trait HttpRequestLoggingSupport extends HttpRequestProxySupport { self: AppLoggi
     import requestContext.tenant
 
     val start = System.nanoTime()
-    logger.info(
-      s"Request: [${req.method.value}] ${req.uri.toString}, RequestHeaders: ${req.getHeaders.toString}, RequestBody: ${maskLog(req.entity.toString)}",
-    )
+    Unmarshal(req).to[String].onComplete { triedString =>
+      val requestBody = triedString.toEither.left.map { throwable =>
+        logger.warn(throwable, "Failed to get the request body")
+        req.entity.toString
+      }.merge
+      logger.info(
+        s"Request: [${req.method.value}] ${req.uri.toString}, RequestHeaders: ${req.getHeaders.toString}, RequestBody: ${maskLog(requestBody)}",
+      )
+    }
 
     Future
       .firstCompletedOf(

--- a/lerna-http/src/main/scala/lerna/http/directives/RequestLogDirective.scala
+++ b/lerna-http/src/main/scala/lerna/http/directives/RequestLogDirective.scala
@@ -2,6 +2,7 @@ package lerna.http.directives
 
 import akka.http.scaladsl.server.directives.BasicDirectives
 import akka.http.scaladsl.server.{ Directive0, RouteResult }
+import akka.http.scaladsl.unmarshalling.Unmarshal
 import lerna.log.{ AppLogging, LogContext }
 
 /** A trait that provides custom logging ''Akka HTTP'' directives
@@ -23,19 +24,33 @@ trait RequestLogDirective extends GenTraceIDDirective with AppLogging {
     */
   def logRequestResultDirective(implicit logContext: LogContext): Directive0 =
     extractRequest flatMap { req =>
-      mapRouteResult { routeResult =>
-        routeResult match {
-          case RouteResult.Complete(res) =>
-            logger.info(
-              s"Response: ${req.uri.path.toString} : ${res.status.toString}, ResponseHeaders: ${res.getHeaders.toString}, " +
-              s"RequestBody: ${req.entity.toString.replaceAll("\n", "")}, " +
-              s"ResponseBody: ${res.entity.toString.replaceAll("\n", "")}",
-            )
-          case _ => // no log entries for rejections
-        }
+      extractMaterializer flatMap { implicit materializer =>
+        extractExecutionContext flatMap { implicit executionContext =>
+          mapRouteResult { routeResult =>
+            routeResult match {
+              case RouteResult.Complete(res) =>
+                for {
+                  requestBody <- Unmarshal(req).to[String].recover {
+                    case throwable =>
+                      logger.warn(throwable, "Failed to get the request body")
+                      req.entity.toString
+                  }
+                  responseBody <- Unmarshal(res).to[String].recover {
+                    case throwable =>
+                      logger.warn(throwable, "Failed to get the response body")
+                      res.entity.toString
+                  }
+                } logger.info(
+                  s"Response: ${req.uri.path.toString} : ${res.status.toString}, ResponseHeaders: ${res.getHeaders.toString}, " +
+                  s"RequestBody: ${requestBody.replaceAll("\n", "")}, " +
+                  s"ResponseBody: ${responseBody.replaceAll("\n", "")}",
+                )
+              case _ => // no log entries for rejections
+            }
 
-        routeResult
+            routeResult
+          }
+        }
       }
     }
-
 }

--- a/lerna-http/src/main/scala/lerna/http/directives/RequestLogDirective.scala
+++ b/lerna-http/src/main/scala/lerna/http/directives/RequestLogDirective.scala
@@ -16,7 +16,7 @@ trait RequestLogDirective extends GenTraceIDDirective with AppLogging {
     */
   def logRequestDirective(implicit logContext: LogContext): Directive0 =
     extractRequest map { req =>
-      logger info s"Request: [${req.method.value}] ${req.uri.path.toString}, RequestHeaders: ${req.getHeaders.toString}"
+      logger info s"Request: [${req.method.value}] ${req.uri.toRelative.toString}, RequestHeaders: ${req.getHeaders.toString}"
     }
 
   /** A directive that logs verbose of the response and the ''TraceID''
@@ -41,7 +41,7 @@ trait RequestLogDirective extends GenTraceIDDirective with AppLogging {
                       res.entity.toString
                   }
                 } logger.info(
-                  s"Response: ${req.uri.path.toString} : ${res.status.toString}, ResponseHeaders: ${res.getHeaders.toString}, " +
+                  s"Response: ${req.uri.toRelative.toString} : ${res.status.toString}, ResponseHeaders: ${res.getHeaders.toString}, " +
                   s"RequestBody: ${requestBody.replaceAll("\n", "")}, " +
                   s"ResponseBody: ${responseBody.replaceAll("\n", "")}",
                 )

--- a/lerna-http/src/test/scala/lerna/http/HttpRequestLoggingSupportSpec.scala
+++ b/lerna-http/src/test/scala/lerna/http/HttpRequestLoggingSupportSpec.scala
@@ -64,18 +64,18 @@ class HttpRequestLoggingSupportSpec extends ScalaTestWithTypedActorTestKit() wit
             .withEntity(responseBody)
         }
       val binding = Await.result(bindingFuture, 3.seconds.dilated)
-      val port    = binding.localAddress.getPort.toString
-      port
+      val origin  = s"http://${binding.localAddress.getHostName}:${binding.localAddress.getPort.toString}"
+      origin
     }
 
     "URL を リクエストログに 出力する" in {
-      val port = startServer("127.0.0.3")
+      val origin = startServer("127.0.0.3")
       val request = HttpRequest()
         .withMethod(HttpMethods.GET)
-        .withUri(s"http://127.0.0.3:$port/dummy-path?key=value")
+        .withUri(s"$origin/dummy-path?key=value")
 
       LoggingTestKit
-        .info(s"Request: [GET] http://127.0.0.3:$port/dummy-path?key=value")
+        .info(s"Request: [GET] $origin/dummy-path?key=value")
         .expect {
           new HttpRequestLoggingSupportForTyped(system)
             .httpSingleRequestWithAroundLogWithTimeout(request, timeout = 1.second.dilated)
@@ -83,9 +83,9 @@ class HttpRequestLoggingSupportSpec extends ScalaTestWithTypedActorTestKit() wit
     }
 
     "HTTP Header を リクエストログに 出力する" in {
-      val port = startServer()
+      val origin = startServer()
       val request = HttpRequest()
-        .withUri(s"http://127.0.0.1:$port/")
+        .withUri(s"$origin/")
         .addHeader(RawHeader("X-dummy-header", "dummy-value"))
 
       LoggingTestKit
@@ -97,9 +97,9 @@ class HttpRequestLoggingSupportSpec extends ScalaTestWithTypedActorTestKit() wit
     }
 
     "HTTP Body を リクエストログに 出力する" in {
-      val port = startServer()
+      val origin = startServer()
       val request = HttpRequest()
-        .withUri(s"http://127.0.0.1:$port/")
+        .withUri(s"$origin/")
         .withEntity("dummy-body")
 
       LoggingTestKit
@@ -111,12 +111,12 @@ class HttpRequestLoggingSupportSpec extends ScalaTestWithTypedActorTestKit() wit
     }
 
     "URL を レスポンスログに 出力する" in {
-      val port = startServer("127.0.0.5")
+      val origin = startServer("127.0.0.5")
       val request = HttpRequest()
-        .withUri(s"http://127.0.0.5:$port/dummy-path?key=value")
+        .withUri(s"$origin/dummy-path?key=value")
 
       LoggingTestKit
-        .info(s"Response: http://127.0.0.5:$port/dummy-path?key=value")
+        .info(s"Response: $origin/dummy-path?key=value")
         .expect {
           new HttpRequestLoggingSupportForTyped(system)
             .httpSingleRequestWithAroundLogWithTimeout(request, timeout = 1.second.dilated)
@@ -124,9 +124,9 @@ class HttpRequestLoggingSupportSpec extends ScalaTestWithTypedActorTestKit() wit
     }
 
     "HTTP Header を レスポンスログに 出力する" in {
-      val port = startServer(responseHeader = Option(RawHeader("X-dummy-header", "dummy-value")))
+      val origin = startServer(responseHeader = Option(RawHeader("X-dummy-header", "dummy-value")))
       val request = HttpRequest()
-        .withUri(s"http://127.0.0.1:$port/")
+        .withUri(s"$origin/")
 
       LoggingTestKit
         .info("ResponseHeaders: [X-dummy-header: dummy-value,")
@@ -137,9 +137,9 @@ class HttpRequestLoggingSupportSpec extends ScalaTestWithTypedActorTestKit() wit
     }
 
     "HTTP Body を レスポンスログに 出力する" in {
-      val port = startServer(responseBody = "dummy-body")
+      val origin = startServer(responseBody = "dummy-body")
       val request = HttpRequest()
-        .withUri(s"http://127.0.0.1:$port/")
+        .withUri(s"$origin/")
 
       LoggingTestKit
         .info("ResponseBody: dummy-body")

--- a/lerna-http/src/test/scala/lerna/http/HttpRequestLoggingSupportSpec.scala
+++ b/lerna-http/src/test/scala/lerna/http/HttpRequestLoggingSupportSpec.scala
@@ -1,9 +1,18 @@
 package lerna.http
 
+import akka.actor.testkit.typed.scaladsl.{ LoggingTestKit, TestDuration }
 import akka.actor.{ typed, ActorSystem }
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.headers.RawHeader
+import akka.http.scaladsl.model.{ HttpMethods, HttpRequest, HttpResponse }
 import lerna.log.AppLogging
 import lerna.testkit.akka.ScalaTestWithTypedActorTestKit
 import lerna.tests.LernaBaseSpec
+import lerna.util.tenant.Tenant
+import lerna.util.trace.{ RequestContext, TraceId }
+
+import scala.concurrent.duration._
+import scala.concurrent.{ Await, Future }
 
 private object HttpRequestLoggingSupportSpec {
   class HttpRequestLoggingSupportForClassic(
@@ -21,6 +30,7 @@ private object HttpRequestLoggingSupportSpec {
   }
 }
 
+@SuppressWarnings(Array("lerna.warts.Awaits"))
 class HttpRequestLoggingSupportSpec extends ScalaTestWithTypedActorTestKit() with LernaBaseSpec {
   import HttpRequestLoggingSupportSpec._
 
@@ -33,6 +43,110 @@ class HttpRequestLoggingSupportSpec extends ScalaTestWithTypedActorTestKit() wit
     "Typed ActorSystem を使ってインスタンス化できる" in {
       val typedSystem: typed.ActorSystem[_] = system
       noException should be thrownBy new HttpRequestLoggingSupportForTyped(typedSystem)
+    }
+
+    implicit val requestContext: RequestContext = new RequestContext {
+      override def traceId: TraceId = TraceId.unknown
+      override implicit def tenant: Tenant = new Tenant {
+        override def id: String = "dummy"
+      }
+    }
+    def startServer(
+        interface: String = "127.0.0.1",
+        responseHeader: Option[RawHeader] = None,
+        responseBody: String = "",
+    ): String = {
+      val bindingFuture: Future[Http.ServerBinding] = Http()
+        .newServerAt(interface, port = 0)
+        .bindSync { _ =>
+          HttpResponse()
+            .withHeaders(responseHeader.toList)
+            .withEntity(responseBody)
+        }
+      val binding = Await.result(bindingFuture, 3.seconds.dilated)
+      val port    = binding.localAddress.getPort.toString
+      port
+    }
+
+    "URL を リクエストログに 出力する" in {
+      val port = startServer("127.0.0.3")
+      val request = HttpRequest()
+        .withMethod(HttpMethods.GET)
+        .withUri(s"http://127.0.0.3:$port/dummy-path?key=value")
+
+      LoggingTestKit
+        .info(s"Request: [GET] http://127.0.0.3:$port/dummy-path?key=value")
+        .expect {
+          new HttpRequestLoggingSupportForTyped(system)
+            .httpSingleRequestWithAroundLogWithTimeout(request, timeout = 1.second.dilated)
+        }
+    }
+
+    "HTTP Header を リクエストログに 出力する" in {
+      val port = startServer()
+      val request = HttpRequest()
+        .withUri(s"http://127.0.0.1:$port/")
+        .addHeader(RawHeader("X-dummy-header", "dummy-value"))
+
+      LoggingTestKit
+        .info("RequestHeaders: [X-dummy-header: dummy-value]")
+        .expect {
+          new HttpRequestLoggingSupportForTyped(system)
+            .httpSingleRequestWithAroundLogWithTimeout(request, timeout = 1.second.dilated)
+        }
+    }
+
+    "HTTP Body を リクエストログに 出力する" in {
+      val port = startServer()
+      val request = HttpRequest()
+        .withUri(s"http://127.0.0.1:$port/")
+        .withEntity("dummy-body")
+
+      LoggingTestKit
+        .info("RequestBody: HttpEntity.Strict(text/plain; charset=UTF-8,10 bytes total)") // FIXME: body が出ない
+        .expect {
+          new HttpRequestLoggingSupportForTyped(system)
+            .httpSingleRequestWithAroundLogWithTimeout(request, timeout = 1.second.dilated)
+        }
+    }
+
+    "URL を レスポンスログに 出力する" in {
+      val port = startServer("127.0.0.5")
+      val request = HttpRequest()
+        .withUri(s"http://127.0.0.5:$port/dummy-path?key=value")
+
+      LoggingTestKit
+        .info(s"Response: http://127.0.0.5:$port/dummy-path?key=value")
+        .expect {
+          new HttpRequestLoggingSupportForTyped(system)
+            .httpSingleRequestWithAroundLogWithTimeout(request, timeout = 1.second.dilated)
+        }
+    }
+
+    "HTTP Header を レスポンスログに 出力する" in {
+      val port = startServer(responseHeader = Option(RawHeader("X-dummy-header", "dummy-value")))
+      val request = HttpRequest()
+        .withUri(s"http://127.0.0.1:$port/")
+
+      LoggingTestKit
+        .info("ResponseHeaders: [X-dummy-header: dummy-value,")
+        .expect {
+          new HttpRequestLoggingSupportForTyped(system)
+            .httpSingleRequestWithAroundLogWithTimeout(request, timeout = 1.second.dilated)
+        }
+    }
+
+    "HTTP Body を レスポンスログに 出力する" in {
+      val port = startServer(responseBody = "dummy-body")
+      val request = HttpRequest()
+        .withUri(s"http://127.0.0.1:$port/")
+
+      LoggingTestKit
+        .info("ResponseBody: HttpEntity.Strict(text/plain; charset=UTF-8,10 bytes total)") // FIXME: body が出ない
+        .expect {
+          new HttpRequestLoggingSupportForTyped(system)
+            .httpSingleRequestWithAroundLogWithTimeout(request, timeout = 1.second.dilated)
+        }
     }
   }
 }

--- a/lerna-http/src/test/scala/lerna/http/HttpRequestLoggingSupportSpec.scala
+++ b/lerna-http/src/test/scala/lerna/http/HttpRequestLoggingSupportSpec.scala
@@ -142,7 +142,7 @@ class HttpRequestLoggingSupportSpec extends ScalaTestWithTypedActorTestKit() wit
         .withUri(s"http://127.0.0.1:$port/")
 
       LoggingTestKit
-        .info("ResponseBody: HttpEntity.Strict(text/plain; charset=UTF-8,10 bytes total)") // FIXME: body が出ない
+        .info("ResponseBody: dummy-body")
         .expect {
           new HttpRequestLoggingSupportForTyped(system)
             .httpSingleRequestWithAroundLogWithTimeout(request, timeout = 1.second.dilated)

--- a/lerna-http/src/test/scala/lerna/http/HttpRequestLoggingSupportSpec.scala
+++ b/lerna-http/src/test/scala/lerna/http/HttpRequestLoggingSupportSpec.scala
@@ -103,7 +103,7 @@ class HttpRequestLoggingSupportSpec extends ScalaTestWithTypedActorTestKit() wit
         .withEntity("dummy-body")
 
       LoggingTestKit
-        .info("RequestBody: HttpEntity.Strict(text/plain; charset=UTF-8,10 bytes total)") // FIXME: body が出ない
+        .info("RequestBody: dummy-body")
         .expect {
           new HttpRequestLoggingSupportForTyped(system)
             .httpSingleRequestWithAroundLogWithTimeout(request, timeout = 1.second.dilated)

--- a/lerna-http/src/test/scala/lerna/http/directives/RequestLogDirectiveSpec.scala
+++ b/lerna-http/src/test/scala/lerna/http/directives/RequestLogDirectiveSpec.scala
@@ -1,0 +1,86 @@
+package lerna.http.directives
+
+import akka.actor.testkit.typed.scaladsl.LoggingTestKit
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.adapter._
+import akka.http.scaladsl.model.headers.RawHeader
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import lerna.http.LernaHttpBaseSpec
+import lerna.log.SystemComponentLogContext
+
+class RequestLogDirectiveSpec extends LernaHttpBaseSpec with ScalatestRouteTest with RequestLogDirective {
+  import SystemComponentLogContext.logContext
+  implicit private def typedSystem: ActorSystem[Nothing] = system.toTyped
+
+  "RequestLogDirective.logRequestDirective" should {
+    val route = logRequestDirective & complete("")
+
+    "URL を リクエストログに 出力する" in {
+      val request = Get("/dummy-path/123")
+
+      LoggingTestKit
+        .info("Request: [GET] /dummy-path/123,")
+        .expect {
+          request ~> route
+        }
+    }
+
+    "HTTP Header を リクエストログに 出力する" in {
+      val request = Get() ~> addHeader("X-dummy-header", "dummy-value")
+
+      LoggingTestKit
+        .info("RequestHeaders: [X-dummy-header: dummy-value]")
+        .expect {
+          request ~> route
+        }
+    }
+  }
+
+  "RequestLogDirective.logRequestResultDirective" should {
+    "URL を レスポンスログに 出力する" in {
+      val request = Get("/dummy-path/123")
+      val route   = logRequestResultDirective & complete("")
+
+      LoggingTestKit
+        .info("Response: /dummy-path/123 : 200 OK,")
+        .expect {
+          request ~> route
+        }
+    }
+
+    "HTTP Header を レスポンスログに 出力する" in {
+      val request = Get()
+      val route =
+        logRequestResultDirective & respondWithHeaders(RawHeader("X-dummy-header", "dummy-value")) & complete("")
+
+      LoggingTestKit
+        .info("ResponseHeaders: [X-dummy-header: dummy-value]")
+        .expect {
+          request ~> route
+        }
+    }
+
+    "HTTP Request Body を レスポンスログに 出力する" in { // Request Body はすべての処理が終わった後にレスポンスログに含めて出す仕様
+      val request = Post().withEntity("dummy-body")
+      val route   = logRequestResultDirective & complete("")
+
+      LoggingTestKit
+        .info("RequestBody: HttpEntity.Strict(text/plain; charset=UTF-8,10 bytes total),") // FIXME: body が出ない
+        .expect {
+          request ~> route
+        }
+    }
+
+    "HTTP Response Body を レスポンスログに 出力する" in {
+      val request = Get()
+      val route   = logRequestResultDirective & complete("dummy-body")
+
+      LoggingTestKit
+        .info("ResponseBody: HttpEntity.Strict(text/plain; charset=UTF-8,10 bytes total)") // FIXME: body が出ない
+        .expect {
+          request ~> route
+        }
+    }
+  }
+}

--- a/lerna-http/src/test/scala/lerna/http/directives/RequestLogDirectiveSpec.scala
+++ b/lerna-http/src/test/scala/lerna/http/directives/RequestLogDirectiveSpec.scala
@@ -17,10 +17,10 @@ class RequestLogDirectiveSpec extends LernaHttpBaseSpec with ScalatestRouteTest 
     val route = logRequestDirective & complete("")
 
     "URL を リクエストログに 出力する" in {
-      val request = Get("/dummy-path/123")
+      val request = Get("http://example.com:8080/dummy-path/123?key1=value1&key2=value2")
 
       LoggingTestKit
-        .info("Request: [GET] /dummy-path/123,")
+        .info("Request: [GET] /dummy-path/123?key1=value1&key2=value2,")
         .expect {
           request ~> route
         }
@@ -39,11 +39,11 @@ class RequestLogDirectiveSpec extends LernaHttpBaseSpec with ScalatestRouteTest 
 
   "RequestLogDirective.logRequestResultDirective" should {
     "URL を レスポンスログに 出力する" in {
-      val request = Get("/dummy-path/123")
+      val request = Get("http://example.com:8080/dummy-path/123?key1=value1&key2=value2")
       val route   = logRequestResultDirective & complete("")
 
       LoggingTestKit
-        .info("Response: /dummy-path/123 : 200 OK,")
+        .info("Response: /dummy-path/123?key1=value1&key2=value2 : 200 OK,")
         .expect {
           request ~> route
         }

--- a/lerna-http/src/test/scala/lerna/http/directives/RequestLogDirectiveSpec.scala
+++ b/lerna-http/src/test/scala/lerna/http/directives/RequestLogDirectiveSpec.scala
@@ -66,7 +66,7 @@ class RequestLogDirectiveSpec extends LernaHttpBaseSpec with ScalatestRouteTest 
       val route   = logRequestResultDirective & complete("")
 
       LoggingTestKit
-        .info("RequestBody: HttpEntity.Strict(text/plain; charset=UTF-8,10 bytes total),") // FIXME: body が出ない
+        .info("RequestBody: dummy-body,")
         .expect {
           request ~> route
         }
@@ -77,7 +77,7 @@ class RequestLogDirectiveSpec extends LernaHttpBaseSpec with ScalatestRouteTest 
       val route   = logRequestResultDirective & complete("dummy-body")
 
       LoggingTestKit
-        .info("ResponseBody: HttpEntity.Strict(text/plain; charset=UTF-8,10 bytes total)") // FIXME: body が出ない
+        .info("ResponseBody: dummy-body")
         .expect {
           request ~> route
         }


### PR DESCRIPTION
## 解決する問題
- [x] HTTP body がログ出力されない (client)
- [x] HTTP body がログ出力されない (server)
- [x] URL の query がログ出力されない (server)

## 関連
- https://github.com/lerna-stack/lerna-app-library/issues/34 ```HTTP リクエスト/レスポンス body がログに出ない · Issue #34 · lerna-stack/lerna-app-library```


## 参考
- [Asynchronous testing • Akka Documentation](https://doc.akka.io/docs/akka/current/typed/testing-async.html#test-of-logging)

> Test of logging  
> To verify that certain logging events are emitted there is a utility called LoggingTestKit . You define a criteria of the expected logging events and it will assert that the given number of occurrences of matching logging events are emitted within a block of code.  