### PR TITLE
Java8 と Java11 に対してテストを実行する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,10 @@ jobs:
   test:
 
     runs-on: ubuntu-latest
-
+    name: Test (Java ${{ matrix.java }})
+    strategy:
+      matrix:
+        java: [ '8', '11' ]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
@@ -24,10 +27,11 @@ jobs:
           # https://github.com/dwijnand/sbt-dynver/tree/v4.1.1#previous-version-detection
           fetch-depth: 0
 
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          distribution: 'zulu'
+          java-version: ${{ matrix.java }}
 
       # https://www.scala-sbt.org/1.x/docs/GitHub-Actions-with-sbt.html#Caching
       - name: Coursier cache
@@ -63,7 +67,7 @@ jobs:
       - name: Publish test report
         uses: mikepenz/action-junit-report@v2
         with:
-          check_name: ScalaTest Report
+          check_name: ScalaTest Report (Java ${{ matrix.java }})
           report_paths: 'lerna-*/target/scala-*/test-reports/TEST-*.xml'
           github_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `lerna-testkit`: Added testkit for TypedActor
 - `lerna-log`: Added Logger for TypedActor
 - `lerna-util-akka`: Added `AtLeastOnceDelivery` API for TypedActor 
+- Java11 support
 
 ### Changed
 - `lerna-management`

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ A library that is useful for building applications that run on Lerna Stack.
     - *Lerna Validation* library provides custom validators for [Accord]
 - [**lerna-wart-core**](doc/lerna-wart-core.md)
     - *Lerna Wart Core* library provides custom warts for [WartRemover]
+    
+The above modules are tested with OpenJDK8 and OpenJDK11.
 
 [Accord]: http://wix.github.io/accord/
 [Akka]: https://doc.akka.io/docs/akka/current/


### PR DESCRIPTION
Closes https://github.com/lerna-stack/lerna-app-library/issues/37

Java8, Java11 のどちらでも動作することを保証するため、
CI で Java8 と Java11 に対してテストを実施します。

Java8 と Java11 に対するテストは並列に実行されます。

[追記]
- setup-java を v2 に更新しました
マイグレーションガイドは次のリンクから確認できます。
[setup-java/switching-to-v2.md at main · actions/setup-java](https://github.com/actions/setup-java/blob/main/docs/switching-to-v2.md)

- 異なる Java バージョンに対してテストする方法は次のリンクから確認できます。
  - [Testing against different Java versions | actions/setup-java: Set up your GitHub Actions workflow with a specific version of Java](https://github.com/actions/setup-java#testing-against-different-java-versions)
  - [`jobs.<job_id>.strategy.matrix` | Workflow syntax for GitHub Actions - GitHub Docs](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix)