### PR TITLE
sbt-api-mappings 3.0.0 に更新する

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,7 +13,7 @@ addSbtPlugin("com.thesamet"                    % "sbt-protoc"     % "1.0.2")
 libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.3"
 
 // Documentation
-addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "2.0.0")
+addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.0")
 addSbtPlugin("com.github.tkawachi"               % "sbt-doctest"      % "0.9.7")
 addSbtPlugin("com.eed3si9n"                      % "sbt-unidoc"       % "0.4.3")
 addSbtPlugin("org.scalameta"                     % "sbt-mdoc"         % "2.2.12")


### PR DESCRIPTION
sbt-api-mappings 2.0.0 と Java11 で次のようなエラーが発生しました。
sbt-api-mappings を 更新するとエラーを解決できました。
```
[error] scala.MatchError: 11 (of class java.lang.String)
[error]        at com.thoughtworks.sbtApiMappings.BootstrapApiMappings$.$anonfun$globalSettings$1(BootstrapApiMappings.scala:28)
[error]        at sbt.internal.util.Init$Value.$anonfun$apply$3(Settings.scala:823)
[error]        at sbt.internal.util.EvaluateSettings.$anonfun$constant$1(INode.scala:206)
[error]        at sbt.internal.util.EvaluateSettings$MixedNode.evaluate0(INode.scala:223)
[error]        at sbt.internal.util.EvaluateSettings$INode.evaluate(INode.scala:166)
[error]        at sbt.internal.util.EvaluateSettings.$anonfun$submitEvaluate$1(INode.scala:87)
[error]        at sbt.internal.util.EvaluateSettings.sbt$internal$util$EvaluateSettings$$run0(INode.scala:99)
[error]        at sbt.internal.util.EvaluateSettings$$anon$3.run(INode.scala:94)
[error]        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
[error]        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
[error]        at java.base/java.lang.Thread.run(Thread.java:829)
[error] scala.MatchError: 11 (of class java.lang.String)
```

sbt-api-mappings は 3.0.0 を利用することができます。
次のリンクから確認できます。
https://search.maven.org/artifact/com.thoughtworks.sbt-api-mappings/sbt-api-mappings/3.0.0/jar

`sbt unidoc` にて生成される Scaladoc に、
他ライブラリのScaladocへのリンクが含まれていることも確認できました。

![lerna_management_stats_Metrics html](https://user-images.githubusercontent.com/5388508/123586366-92002180-d81f-11eb-8ea7-1a83672503e5.png)

