### PR TITLE
test: 環境に依存する設定値が使用されているテストを削除

### DIFF
--- a/lerna-management/src/test/scala/lerna/management/stats/MetricsImplSpec.scala
+++ b/lerna-management/src/test/scala/lerna/management/stats/MetricsImplSpec.scala
@@ -70,14 +70,6 @@ object MetricsImplSpec {
                                |      }
                                |    }
                                |
-                               |    /system-metrics/host/network/bytes {
-                               |      name = "host.network.data.read"
-                               |      tags {
-                               |        component = "host"
-                               |        interface = "eth0"
-                               |      }
-                               |    }
-                               |
                                |    /not-exits-value {
                                |      name = "dummy"
                                |      null-value = "0"
@@ -255,16 +247,6 @@ class MetricsImplSpec extends LernaManagementActorBaseSpec(ActorSystem("MetricsI
         timeout,
       ) { metrics =>
         expect(metrics.value.toLong > 0)
-      }
-    }
-
-    "host_network_bytes" in {
-      val key = MetricsKey("system-metrics/host/network/bytes", None)
-      whenReady(
-        retry(() => metricsImpl.getMetrics(key).map(_.get), attempts, delay),
-        timeout,
-      ) { metrics =>
-        expect(metrics.value.nonEmpty)
       }
     }
 


### PR DESCRIPTION
Windows環境でテストが通らなかった。

> interface = "eth0"

元々冗長なテストだった

## 関連
- https://github.com/lerna-stack/lerna-app-library/pull/14 ```kamon 2.1.18 に更新する by xirc · Pull Request #14 · lerna-stack/lerna-app-library```
  - https://github.com/lerna-stack/lerna-app-library/commit/aa5ef2c49#diff-036b6cfb00f2adea9a01c520ff5f53d9386b8a50835f99fff7a14c4556eda312 ```feat: Upgrade to Kamon 2.1.18 · lerna-stack/lerna-app-library@aa5ef2c```