### PR TITLE
chore: Kamon.systemMetrics 依存 を `% Test` に変更

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `lerna-management`
   - Update to `Kamon 2.1.8` from `Kamon 1.1.6`
+  - Remove the `kamon-system-metrics` dependency as it is not required for everyone. If you are using it, you need to add a dependency.
   - Improve documentation
   - Provide [migration guide](doc/migration-guide.md)
 - Update to `ScalaTest 3.1.4` from `ScalaTest 3.0.9`

--- a/build.sbt
+++ b/build.sbt
@@ -279,7 +279,7 @@ lazy val lernaManagement = lernaModule("lerna-management")
     libraryDependencies ++= Seq(
       Dependencies.Akka.actorTyped,
       Dependencies.Kamon.core,
-      Dependencies.Kamon.systemMetrics,
+      Dependencies.Kamon.systemMetrics    % Test,
       Dependencies.Akka.actorTestKitTyped % Test,
     ),
   )


### PR DESCRIPTION
testでしか使用していないため

- kamon-system-metrics を利用しないユーザは、依存ライブラリが減ることになります。
- kamon-system-metrics を利用しているユーザは、自身で kamon-system-metrics を依存ライブラリに追加できます。

## 関連
- https://github.com/lerna-stack/lerna-app-library/issues/15 `` `lerna-management` の `kamon-system-metrics` 依存 を `Test` のみにしたい · Issue #15 · lerna-stack/lerna-app-library``