### PR TITLE
lerna-util-sequence SequenceFactoryWorker テストケース追加

### DIFF
--- a/lerna-util-sequence/src/test/scala/lerna/util/sequence/SequenceFactoryWorkerSpec.scala
+++ b/lerna-util-sequence/src/test/scala/lerna/util/sequence/SequenceFactoryWorkerSpec.scala
@@ -195,6 +195,67 @@ class SequenceFactoryWorkerSpec
 
       testKit.stop(worker)
     }
+
+    "予約中の採番要求で次番号が上限を超えた場合はリセットする" in {
+      val storeProbe        = createTestProbe[SequenceStore.Command]()
+      val firstValue        = 3
+      val incrementStep     = 10
+      val maxSequenceValue  = 15 // 3 + 10 = 13 < 15 < 23 = 3 + 10 * 2
+      val reservationAmount = 2
+      val worker = spawn(
+        SequenceFactoryWorker
+          .apply(
+            maxSequenceValue = maxSequenceValue,
+            firstValue = firstValue,
+            incrementStep = incrementStep,
+            reservationAmount = reservationAmount,
+            storeProbe.ref,
+            idleTimeout = 10.seconds,
+            sequenceSubId,
+          ),
+      )
+
+      // 初期化
+      inside(storeProbe.receiveMessage()) {
+        case result: SequenceStore.InitialReserveSequence =>
+          result.replyTo ! SequenceStore.InitialSequenceReserved(
+            initialValue = firstValue,
+            maxReservedValue = firstValue + (incrementStep * (reservationAmount - 1)),
+          )
+      }
+
+      // 採番できる 1
+      {
+        val replyToProbe = createTestProbe[SequenceFactoryWorker.SequenceGenerated]()
+        worker ! SequenceFactoryWorker.GenerateSequence(sequenceSubId, replyToProbe.ref)
+        replyToProbe.expectMessage(SequenceFactoryWorker.SequenceGenerated(firstValue, sequenceSubId))
+      }
+
+      storeProbe.receiveMessage() shouldBe a[SequenceStore.ReserveSequence]
+
+      // 採番できる 2
+      {
+        val replyToProbe = createTestProbe[SequenceFactoryWorker.SequenceGenerated]()
+        worker ! SequenceFactoryWorker.GenerateSequence(sequenceSubId, replyToProbe.ref)
+        replyToProbe.expectMessage(SequenceFactoryWorker.SequenceGenerated(firstValue + incrementStep, sequenceSubId))
+      }
+
+      // 採番要求
+      {
+        val replyToProbe = createTestProbe[SequenceFactoryWorker.SequenceGenerated]()
+        worker ! SequenceFactoryWorker.GenerateSequence(sequenceSubId, replyToProbe.ref)
+      }
+
+      // newNextValue > maxSequenceValue の場合、リセットされる
+      inside(storeProbe.receiveMessage()) {
+        case result: SequenceStore.ResetReserveSequence =>
+          expect(result.firstValue === BigInt(firstValue))
+          expect(result.reservationAmount === reservationAmount)
+          expect(result.sequenceSubId === sequenceSubId)
+      }
+
+      testKit.stop(worker)
+    }
   }
 
 }


### PR DESCRIPTION
[lerna-app-library/SequenceFactoryWorker.scala](https://github.com/lerna-stack/lerna-app-library/blob/ab5c7912d07e2515d726665a539cb3ad5231bfb7/lerna-util-sequence/src/main/scala/lerna/util/sequence/SequenceFactoryWorker.scala) の

- `notReady` -> `resetting`
- `ready` -> `resetting`
- `reserving` -> `resetting`
- `reserving` -> `reserving`
- `resetting` -> `ready`

を通るようになりました。