### PR TITLE
Version up 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-[Unreleased]: https://github.com/lerna-stack/lerna-app-library/compare/v1.0.0...main
+[Unreleased]: https://github.com/lerna-stack/lerna-app-library/compare/v2.0.0...main
+
+
+
+## [v2.0.0] - 2021-07-16
+[v2.0.0]: https://github.com/lerna-stack/lerna-app-library/compare/v1.0.0...v2.0.0
 
 ### Fixed
 - `lerna-http`

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The above modules are tested with OpenJDK8 and OpenJDK11.
 To use these library modules, you must add dependencies into your sbt project, add the following lines to your `build.sbt` file:
 
 ```scala
-val LernaVersion = "1.0.0"
+val LernaVersion = "2.0.0"
 
 libraryDependencies += "com.lerna-stack" %% "lerna-http"          % LernaVersion
 libraryDependencies += "com.lerna-stack" %% "lerna-log"           % LernaVersion

--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ lazy val `root` = (project in file("."))
   .settings(
     inThisBuild(
       List(
-        version := "1.0.0",
+        version := "2.0.0",
         scalaVersion := scala213,
         scalacOptions ++= Seq(
           "-deprecation",


### PR DESCRIPTION
close https://github.com/lerna-stack/lerna-app-library/issues/11 ```v2.0.0 · Issue #11 · lerna-stack/lerna-app-library```

不要な v1.0.0 は残っていない
```
$ git grep --fixed-string 1.0.0
CHANGELOG.md:The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
CHANGELOG.md:[v2.0.0]: https://github.com/lerna-stack/lerna-app-library/compare/v1.0.0...v2.0.0
CHANGELOG.md:## [v1.0.0] - 2020-12-22
CHANGELOG.md:[v1.0.0]: https://github.com/lerna-stack/lerna-app-library/tree/v1.0.0
doc/migration-guide.md:## 2.0.0 from 1.0.0
```

## TODO(merge後)
- [ ] `v2.0.0` タグを打つ
- [ ] `sbt clean publishSigned`
- [ ] リリース