### PR TITLE
Version up scala

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import scala.util.Try
 
 name := "lerna-app-library"
 
-lazy val scala212               = "2.12.12"
+lazy val scala212               = "2.12.13"
 lazy val scala213               = "2.13.4"
 lazy val supportedScalaVersions = List(scala213, scala212)
 

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import scala.util.Try
 name := "lerna-app-library"
 
 lazy val scala212               = "2.12.13"
-lazy val scala213               = "2.13.4"
+lazy val scala213               = "2.13.6"
 lazy val supportedScalaVersions = List(scala213, scala212)
 
 lazy val `root` = (project in file("."))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,7 +16,7 @@ libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.3"
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.0")
 addSbtPlugin("com.github.tkawachi"               % "sbt-doctest"      % "0.9.7")
 addSbtPlugin("com.eed3si9n"                      % "sbt-unidoc"       % "0.4.3")
-addSbtPlugin("org.scalameta"                     % "sbt-mdoc"         % "2.2.12")
+addSbtPlugin("org.scalameta"                     % "sbt-mdoc"         % "2.2.16")
 
 // publish jar
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")


### PR DESCRIPTION
scala.annotation.nowarn アノテーションを使いたいため

Scala Standard Library 2.12.13 - scala.annotation.nowarn
https://www.scala-lang.org/api/2.12.13/scala/annotation/nowarn.html

※ 2.12.14 に上げると wartremover を 2.4.13 -> 2.4.15 に上げる必要があり、
2.4.15 だと sbt でエラーになる
https://repo1.maven.org/maven2/org/wartremover/wartremover_2.12.14/

> Error:  java.lang.NoSuchMethodError: sbt.Def$.ifS(Lsbt/internal/util/Init$Initialize;Lsbt/internal/util/Init$Initialize;Lsbt/internal/util/Init$Initialize;)Lsbt/internal/util/Init$Initialize;

## mdoc
`2.2.12` のままだと mdoc が使用できなかった

https://github.com/lerna-stack/lerna-app-library/runs/3074987777

```
[info] running mdoc.Main 
Error:  (run-main-0) java.lang.NoClassDefFoundError: scala/tools/nsc/reporters/AbstractReporter
Error:  java.lang.NoClassDefFoundError: scala/tools/nsc/reporters/AbstractReporter
```

2.2.16 への version up でチェックできることは確認済み

```diff
$ git diff
diff --git a/doc/lerna-http.md b/doc/lerna-http.md
index 3c6e8bec4..96b79ebf2 100644
--- a/doc/lerna-http.md
+++ b/doc/lerna-http.md
@@ -45,7 +45,7 @@ ### LocalDateTimeJsonFormat
 ```scala mdoc:reset
 import lerna.http.json.LocalDateTimeJsonFormat
 import spray.json.RootJsonFormat
-import java.time.LocalDateTime
+import java.time.LocalDateTimeeeeeeeeeeeeeeeeeeeeeeeeeee

 implicit val format: RootJsonFormat[LocalDateTime] = LocalDateTimeJsonFormat("yyyy/MM/dd_HH:mm:ss")
```

```
sbt +mdoc
```
```
object LocalDateTimeeeeeeeeeeeeeeeeeeeeeeeeeee is not a member of package java.time
import java.time.LocalDateTimeeeeeeeeeeeeeeeeeeeeeeeeeee
```


## 関連
- Scala 2.13
  - [Release Scala 2.13.5 · scala/scala](https://github.com/scala/scala/releases/tag/v2.13.5)
  - [Release Scala 2.13.6 · scala/scala](https://github.com/scala/scala/releases/tag/v2.13.6)
- Scala 2.12
  - Scala
    - [Release Scala 2.12.13 · scala/scala](https://github.com/scala/scala/releases/tag/v2.12.13)
    - [Release Scala 2.12.14 · scala/scala](https://github.com/scala/scala/releases/tag/v2.12.14)
      - 致命的な 2.12.13 のバグは無し
  - mdoc
    - [Release mdoc v2.2.13 · scalameta/mdoc](https://github.com/scalameta/mdoc/releases/tag/v2.2.13)
    - [Release mdoc v2.2.14 · scalameta/mdoc](https://github.com/scalameta/mdoc/releases/tag/v2.2.14)
    - [Release v2.2.15 · scalameta/mdoc](https://github.com/scalameta/mdoc/releases/tag/v2.2.15)
      - [Comparing v2.2.15...v2.2.16 · scalameta/mdoc](https://github.com/scalameta/mdoc/compare/v2.2.15...v2.2.16)
    - [Release mdoc v2.2.16 · scalameta/mdoc](https://github.com/scalameta/mdoc/releases/tag/v2.2.16)
 