### PR TITLE
Update cassandra-driver-core to 3.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 [Unreleased]: https://github.com/lerna-stack/lerna-app-library/compare/v2.0.0...main
 
+### Changed
+- Update `cassandra-driver-core` to `3.11.0` from `3.7.1`
 
 
 ## [v2.0.0] - 2021-07-16

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
     val airframe              = "20.9.0"
     val akka                  = "2.6.8"
     val akkaHTTP              = "10.2.4"
-    val cassandraDriverCore   = "3.7.1"
+    val cassandraDriverCore   = "3.11.0"
     val kamonCore             = "2.1.18"
     val kamonSystemMetrics    = "2.1.18"
     val logbackClassic        = "1.2.3"


### PR DESCRIPTION
Here is the Upgrade Guide.
https://docs.datastax.com/en/developer/java-driver/3.11/upgrade_guide/

There is no need to change except the version.