### PR TITLE
Update wiremock-jre8 to 2.30.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [Unreleased]: https://github.com/lerna-stack/lerna-app-library/compare/v2.0.0...main
 
 ### Changed
+- Update `wiremock-jre8` to `2.30.1` from `2.27.2`
 - Update `cassandra-driver-core` to `3.11.0` from `3.7.1`
 
 

--- a/doc/lerna-testkit.md
+++ b/doc/lerna-testkit.md
@@ -123,7 +123,7 @@ final class MySpec extends AnyWordSpecLike with Matchers with DISessionSupport {
 ## WireMock
 If you use *WireMock* related features, You need to add `wiremock-jre8` into `libraryDependencies` like the following.
 ```sbt
-libraryDependencies += "com.github.tomakehurst" % "wiremock-jre8" % "2.27.2" % Test
+libraryDependencies += "com.github.tomakehurst" % "wiremock-jre8" % "2.30.1" % Test
 ```
 
 ### ExternalServiceMock

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
     val scalaCollectionCompat = "2.4.4"
     val slf4jAPI              = "1.7.30"
     val typesafeConfig        = "1.4.0"
-    val wireMock              = "2.27.2"
+    val wireMock              = "2.30.1"
   }
 
   object Typesafe {


### PR DESCRIPTION
`"com.github.tomakehurst" % "wiremock-jre8" % "2.30.1"` に更新します。

https://github.com/tomakehurst/wiremock/compare/2.27.2...2.30.1 から差分を確認できます。

多くの更新が含まれており、すべてを確認するのは難しいですが、
必要な機能の unit test が実施されているため、更新によって問題は発生しないと思われます。
https://github.com/lerna-stack/lerna-app-library/blob/v2.0.0/lerna-testkit/src/test/scala/lerna/testkit/wiremock/ExternalServiceMockSpec.scala

WireMock は Guava に依存しています。次の URL から確認できます。
https://github.com/tomakehurst/wiremock/blob/2.27.2/build.gradle#L40-L57

Guava にはいくつかの脆弱性が報告されています。
[CVE - CVE-2018-10237](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-10237)
[CVE - CVE-2020-8908](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8908)

WireMock は脆弱性に該当する機能を使っていないようですが、可能な限り最新版を使うほうが良いでしょう。
WireMock 2.30.1 にすることで、 Guava '30.1.1-jre' まで更新することができます。
https://github.com/tomakehurst/wiremock/blob/2.30.1/build.gradle#L26-L32

※ Guava を最新版にするためには、https://github.com/lerna-stack/lerna-app-library/pull/54 で対応する DataStax Java Driver の更新も必要です。