### PR TITLE
PowerAssertionsSupport.expect は1つの assertion のみを処理する

### DIFF
--- a/lerna-http/src/test/scala/lerna/http/json/AnyValJsonFormatSpec.scala
+++ b/lerna-http/src/test/scala/lerna/http/json/AnyValJsonFormatSpec.scala
@@ -37,10 +37,8 @@ class AnyValJsonFormatSpec extends LernaHttpRouteBaseSpec {
 
     "AnyVal から JSValue に、JSValue から AnyVal に相互に変換可能" in {
       Post("/", HttpEntity(`application/json`, """{ "ex": "01" }""")) ~> Route.seal(route) ~> check {
-        expect {
-          status === StatusCodes.OK
-          responseAs[ExampleObject] === ExampleObject(ExampleVal("01"))
-        }
+        expect(status === StatusCodes.OK)
+        expect(responseAs[ExampleObject] === ExampleObject(ExampleVal("01")))
       }
     }
 

--- a/lerna-http/src/test/scala/lerna/http/json/EnumJsonFormatSpec.scala
+++ b/lerna-http/src/test/scala/lerna/http/json/EnumJsonFormatSpec.scala
@@ -47,10 +47,8 @@ class EnumJsonFormatSpec extends LernaHttpRouteBaseSpec {
     "区分値にある値を受け取ったら case class に変換される" in {
 
       Post("/", HttpEntity(`application/json`, """{ "code": "01" }""")) ~> Route.seal(route) ~> check {
-        expect {
-          status === StatusCodes.OK
-          responseAs[ExampleCode] === ExampleCode.One
-        }
+        expect(status === StatusCodes.OK)
+        expect(responseAs[ExampleCode] === ExampleCode.One)
       }
     }
 

--- a/lerna-http/src/test/scala/lerna/http/json/SnakifiedSprayJsonSupportSpec.scala
+++ b/lerna-http/src/test/scala/lerna/http/json/SnakifiedSprayJsonSupportSpec.scala
@@ -13,10 +13,8 @@ class SnakifiedSprayJsonSupportSpec extends LernaHttpBaseSpec with SnakifiedSpra
 
     val jsonObject = """{"test_string": "test2" }""".parseJson.convertTo[TestString]
 
-    expect {
-      jsonString.toString === """{"test_string":"test1"}"""
-      jsonObject.testString === "test2"
-    }
+    expect(jsonString.toString === """{"test_string":"test1"}""")
+    expect(jsonObject.testString === "test2")
 
   }
 

--- a/lerna-tests/src/main/scala/lerna/tests/PowerAssertionsSupport.scala
+++ b/lerna-tests/src/main/scala/lerna/tests/PowerAssertionsSupport.scala
@@ -7,7 +7,5 @@ import com.eed3si9n.expecty.Expecty
   * @see [[https://github.com/pniederw/expecty Expecty]]
   */
 trait PowerAssertionsSupport {
-  val expect: Expecty = new Expecty {
-    override val failEarly: Boolean = false
-  }
+  val expect: Expecty = new Expecty()
 }

--- a/lerna-tests/src/test/scala/lerna/tests/LernaBaseSpecSpec.scala
+++ b/lerna-tests/src/test/scala/lerna/tests/LernaBaseSpecSpec.scala
@@ -15,13 +15,6 @@ final class LernaBaseSpecSpec extends LernaBaseSpec {
         */
     }
 
-    "複数項目チェックする場合" in {
-      expect {
-        "1" === "1"
-        "2" === "2"
-      }
-    }
-
     "条件を満たさない場合はAssertionErrorになる" in {
       assertThrows[AssertionError] {
         expect("1" === "2")

--- a/lerna-util-akka/src/test/scala/lerna/util/akka/stream/FailureSkipFlowSpec.scala
+++ b/lerna-util-akka/src/test/scala/lerna/util/akka/stream/FailureSkipFlowSpec.scala
@@ -45,11 +45,9 @@ class FailureSkipFlowSpec extends LernaAkkaActorBaseSpec(ActorSystem("FailureSki
       val result = Source(elements).via(flow).runWith(Sink.seq[Int])
 
       whenReady(result) { seq =>
-        expect {
-          seq === Seq(1, 2, 4)
-          failureElement === Option(3)
-          cause === Option(failure)
-        }
+        expect(seq === Seq(1, 2, 4))
+        expect(failureElement === Option(3))
+        expect(cause === Option(failure))
       }
     }
 

--- a/lerna-util-sequence/src/test/scala/lerna/util/sequence/CassandraSequenceFactorySpec.scala
+++ b/lerna-util-sequence/src/test/scala/lerna/util/sequence/CassandraSequenceFactorySpec.scala
@@ -112,12 +112,10 @@ class CassandraSequenceFactorySpec
       })
 
       whenReady(futures) { results =>
-        expect {
-          results.forall(_ === BigInt(1)) // 初項は node-id
-
-          // 全部 採番成功して値がある(そもそもFutureがSuccessなら問題ない)
-          results.size === numberOfValues
-        }
+        // 初項は node-id
+        expect(results.forall(_ === BigInt(1)))
+        // 全部 採番成功して値がある(そもそもFutureがSuccessなら問題ない)
+        expect(results.size === numberOfValues)
       }
     }
 

--- a/lerna-util/src/test/scala/lerna/util/security/SecretValSpec.scala
+++ b/lerna-util/src/test/scala/lerna/util/security/SecretValSpec.scala
@@ -46,10 +46,8 @@ class SecretValSpec extends LernaUtilBaseSpec {
 
     "機密情報のみマスキングされる" in {
       val masked = ExampleContainer(name = "_name_", ExampleValue("_password_").asSecret).toString
-      expect {
-        masked.contains("_name_")
-        !masked.contains("_password_")
-      }
+      expect(masked.contains("_name_"))
+      expect(!masked.contains("_password_"))
     }
   }
 }


### PR DESCRIPTION
Closes https://github.com/lerna-stack/lerna-app-library/issues/50

複数の assertion を処理することを非サポートにします。
`PowerAssertionsSupport.expect` の使用箇所を調べて、複数の `expect` になるように書き換えました。