### PR TITLE
🐞fix: リセット時に採番値が余分に 1 つ多く予約される問題を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       Note that the upgrade doesn't break already-persisted data since the Cassandra database schema to use is not changed.  
       Though we have to migrate code and settings, we can continue to use already-persisted data.
 
+### Fixed
+- `lerna-util-sequence`
+    - Reserving an unnecessary extra sequence value when resetting [PR#65](https://github.com/lerna-stack/lerna-app-library/pull/65)
 
 ## [v2.0.0] - 2021-07-16
 [v2.0.0]: https://github.com/lerna-stack/lerna-app-library/compare/v1.0.0...v2.0.0

--- a/lerna-util-sequence/src/main/scala/lerna/util/sequence/SequenceStore.scala
+++ b/lerna-util-sequence/src/main/scala/lerna/util/sequence/SequenceStore.scala
@@ -401,7 +401,7 @@ private[sequence] final class SequenceStore(
       reservationAmount: BigInt,
       sequenceSubId: Option[String],
   )(implicit sessionContext: SessionContext): Future[SequenceReset] = {
-    reserve(maxReservedValue = firstValue, reservationAmount, sequenceSubId)
+    reserve(maxReservedValue = firstValue, reservationAmount - 1, sequenceSubId)
       .map(r => SequenceReset(r.maxReservedValue))
   }
 

--- a/lerna-util-sequence/src/test/scala/lerna/util/sequence/SequenceFactoryWorkerSpec.scala
+++ b/lerna-util-sequence/src/test/scala/lerna/util/sequence/SequenceFactoryWorkerSpec.scala
@@ -141,7 +141,7 @@ class SequenceFactoryWorkerSpec
 
           val maxReservedValue = firstValue
           result.replyTo ! SequenceStore.SequenceReset(
-            maxReservedValue = maxReservedValue + (incrementStep * reservationAmount),
+            maxReservedValue = maxReservedValue + (incrementStep * (reservationAmount - 1)),
           )
       }
 


### PR DESCRIPTION
Closes #66

`reservationAmount` で指定された分だけリセット時に予約されるよう修正します。