### PR TITLE
🚨test: Cassandra に接続する際のタイムアウトを伸ばしてテストが失敗する確率を減らします

### DIFF
--- a/lerna-util-sequence/src/test/scala/lerna/util/sequence/SequenceStoreSpec.scala
+++ b/lerna-util-sequence/src/test/scala/lerna/util/sequence/SequenceStoreSpec.scala
@@ -4,6 +4,8 @@ import com.typesafe.config.ConfigFactory
 import lerna.testkit.akka.ScalaTestWithTypedActorTestKit
 import lerna.tests.LernaBaseSpec
 import lerna.util.tenant.Tenant
+import org.scalatest.concurrent.PatienceConfiguration.Timeout
+import scala.concurrent.duration._
 
 import java.util.UUID
 
@@ -32,7 +34,7 @@ class SequenceStoreSpec extends ScalaTestWithTypedActorTestKit(SequenceStoreSpec
   private[this] lazy val cassandraConfig = new SequenceFactoryConfig(system.settings.config).cassandraConfig
 
   private lazy val session =
-    CqlSessionProvider.connect(system, cassandraConfig).futureValue
+    CqlSessionProvider.connect(system, cassandraConfig).futureValue(Timeout(15.seconds))
 
   override def beforeAll(): Unit = {
     super.beforeAll()


### PR DESCRIPTION
デフォルトのタイムアウト値は `akka.test.default-timeout` の 5s が設定されますが、DEBUG ログによると Cassandra の接続には 5 秒近い時間がかかっていることがわかります。

> ```
>     # The timeout that is added as an implicit by DefaultTimeout trait
>     default-timeout = 5s
> ```
> **[akka/reference.conf at v2.6.12 · akka/akka](https://github.com/akka/akka/blob/v2.6.12/akka-testkit/src/main/resources/reference.conf#L26-L27)**

**DEBUG ログ：**
```
[info] SequenceStore
11:51:27.036 [SequenceStoreSpec-akka.actor.default-dispatcher-3] DEBUG com.datastax.oss.driver.internal.core.util.Reflection - Could not load com.esri.core.geometry.ogc.OGCGeometry: java.lang.ClassNotFoundException: com.esri.core.geometry.ogc.OGCGeometry
java.lang.ClassNotFoundException: com.esri.core.geometry.ogc.OGCGeometry
.. 略 ...
11:51:31.982 [s1-io-2] DEBUG io.netty.buffer.PoolThreadCache - Freed 19 thread-local buffer(s) from thread: s1-io-2
11:51:32.000 [globalEventExecutor-1-3] DEBUG com.datastax.oss.driver.internal.core.session.DefaultSession - Closing session s1 (1 live instances)
[info] - should 最初の予約では初項（firstValue）が初期値（initialValue）となり、reservationAmount で指定した分だけの採番値が予約される
```

Cassandra の接続時はデフォルトの倍の 10s 待つように変更し、テストを失敗させにくくします。