### PR TITLE
Use a hyphen as a version separator

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,8 +52,9 @@ lazy val `root` = (project in file("."))
         // forkプロセスのstdoutをこのプロセスのstdout,stderrをこのプロセスのstderrに転送する
         // デフォルトのLoggedOutputでは、airframeやkamonが標準エラーに出力するログが[error]とプリフィクスがつき、紛らわしいためです。
         outputStrategy := Some(StdoutOutput),
-        mimaPreviousArtifacts := Set.empty, // default
-        mimaReportSignatureProblems := true,// check also generic parameters
+        mimaPreviousArtifacts := Set.empty,  // default
+        mimaReportSignatureProblems := true, // check also generic parameters
+        dynverSeparator := "-",              // For more compatible with other tools
       ),
     ),
   )


### PR DESCRIPTION
It is more compatible with other tools.
We can change this separator by setting `dynverSeparator` to `-`.

See also: https://github.com/dwijnand/sbt-dynver#portable-version-strings

A new snapshot version looks like the following:
```
$ sbt +publishLocal
(...truncated)
[info]  published ivy to \.ivy2\local\com.lerna-stack\lerna-util-sequence_2.13\3.0.0-3-35dc20da-SNAPSHOT\ivys\ivy.xml
[success] Total time: 23 s, completed 2022/01/24 10:56:58
```