### PR TITLE
Reduce log outputs in tests of lerna-util-sequence

### DIFF
--- a/lerna-util-sequence/src/test/resources/logback-test.xml
+++ b/lerna-util-sequence/src/test/resources/logback-test.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <conversionRule conversionWord="msg" converterClass="lerna.log.logback.converter.OneLineEventConverter" />
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date{HH:mm:ss.SSS}\t%-5level\t%logger\t%X{akkaSource:--}\t%X{traceId:--}\t%X{tenantId:--}\t%msg%xEx%nopex%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger level="INFO" name="akka" />
+    <logger level="DEBUG" name="lerna.util.sequence" />
+
+    <root level="WARN">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
The debug log outputs from `com.datastax.oss.driver` makes us difficult to read the log from `lerna.util.sequence`.

For example:
```
12:06:41.605 [CassandraSequenceFactorySpec-akka.actor.default-dispatcher-11] INFO lerna.util.sequence.SequenceFactoryWorker$ - initial reserved: max:91, initial:1
12:06:41.605 [CassandraSequenceFactorySpec-akka.actor.default-dispatcher-11] DEBUG lerna.util.sequence.SequenceFactoryWorker$ - SequenceGenerated: 1
12:06:41.608 [s14-io-3] DEBUG com.datastax.oss.driver.internal.core.channel.InFlightHandler - [s14|id: 0xd825ec7d, L:/127.0.0.1:50400 - R:/127.0.0.1:9042] Got last response on in-flight stream id 0, completing and releasing
12:06:41.611 [s14-io-3] DEBUG com.datastax.oss.driver.internal.core.channel.InFlightHandler - [s14|id: 0xd825ec7d, L:/127.0.0.1:50400 - R:/127.0.0.1:9042] Got last response on in-flight stream id 0, completing and releasing
12:06:41.611 [CassandraSequenceFactorySpec-akka.actor.default-dispatcher-11] INFO lerna.util.sequence.SequenceStore$ - Reserved > sequenceId: 568e4087-2d88-4769-9036-a981c084dbbb  sequenceSubId: test-29  nodeId: 1  reservedValue: 91
12:06:41.612 [CassandraSequenceFactorySpec-akka.actor.default-dispatcher-13] INFO lerna.util.sequence.SequenceFactoryWorker$ - initial reserved: max:91, initial:1
12:06:41.612 [CassandraSequenceFactorySpec-akka.actor.default-dispatcher-13] DEBUG lerna.util.sequence.SequenceFactoryWorker$ - SequenceGenerated: 1
12:06:41.616 [s14-io-3] DEBUG com.datastax.oss.driver.internal.core.channel.InFlightHandler - [s14|id: 0xd825ec7d, L:/127.0.0.1:50400 - R:/127.0.0.1:9042] Got last response on in-flight stream id 0, completing and releasing
12:06:41.623 [s14-io-3] DEBUG com.datastax.oss.driver.internal.core.channel.InFlightHandler - [s14|id: 0xd825ec7d, L:/127.0.0.1:50400 - R:/127.0.0.1:9042] Got last response on in-flight stream id 0, completing and releasing
12:06:41.623 [CassandraSequenceFactorySpec-akka.actor.default-dispatcher-11] INFO lerna.util.sequence.SequenceStore$ - Reserved > sequenceId: 568e4087-2d88-4769-9036-a981c084dbbb  sequenceSubId: test-30  nodeId: 1  reservedValue: 91
12:06:41.624 [CassandraSequenceFactorySpec-akka.actor.default-dispatcher-13] INFO lerna.util.sequence.SequenceFactoryWorker$ - initial reserved: max:91, initial:1
12:06:41.624 [CassandraSequenceFactorySpec-akka.actor.default-dispatcher-13] DEBUG lerna.util.sequence.SequenceFactoryWorker$ - SequenceGenerated: 1
12:06:41.628 [s14-io-3] DEBUG com.datastax.oss.driver.internal.core.channel.InFlightHandler - [s14|id: 0xd825ec7d, L:/127.0.0.1:50400 - R:/127.0.0.1:9042] Got last response on in-flight stream id 0, completing and releasing
12:06:41.632 [s14-io-3] DEBUG com.datastax.oss.driver.internal.core.channel.InFlightHandler - [s14|id: 0xd825ec7d, L:/127.0.0.1:50400 - R:/127.0.0.1:9042] Got last response on in-flight stream id 0, completing and releasing
```

This change will not affect users.