### PR TITLE
Improve failure detection on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,11 +59,11 @@ jobs:
         run: docker-compose up --build -d cassandra
 
       - name: Run tests
-        continue-on-error: true # results are reported by action-junit-report
         run: sbt coverage +test
 
       - name: Publish test report
         uses: mikepenz/action-junit-report@v2
+        if: ${{ always() }}
         with:
           check_name: ScalaTest Report (Java ${{ matrix.java }})
           report_paths: 'lerna-*/target/scala-*/test-reports/TEST-*.xml'


### PR DESCRIPTION
Closes https://github.com/lerna-stack/lerna-app-library/issues/85

Use `always` instead of `continue-on-error`.
CI will fail if the test runner fails due to initialization errors, etc...

https://github.com/lerna-stack/lerna-app-library/pull/84 verifies CI will fail if a test throws `ExceptionInInitializerError`.