### PR TITLE
maxSequence が Int の最大値よりもかなり大きいとき採番に失敗する問題を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 [Unreleased]: https://github.com/lerna-stack/lerna-app-library/compare/v3.0.1...main
 
+### Fixed
+- `lerna-util-sequence`
+  - fix overflow occurred in a `freeAmount`
+
 ## [v3.0.1] - 2022-03-24
 [v3.0.1]: https://github.com/lerna-stack/lerna-app-library/compare/v3.0.0...v3.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `lerna-util-sequence`
-  - fix overflow occurred in a `freeAmount`
+  - An overflow occurred in numbering process when maxSequence is large value [#89](https://github.com/lerna-stack/lerna-app-library/pull/89)
 
 ## [v3.0.1] - 2022-03-24
 [v3.0.1]: https://github.com/lerna-stack/lerna-app-library/compare/v3.0.0...v3.0.1

--- a/lerna-util-sequence/src/main/mima-filters/3.0.1.backwards.excludes/89-fix-type-of-reservation-amount.backwards.excludes
+++ b/lerna-util-sequence/src/main/mima-filters/3.0.1.backwards.excludes/89-fix-type-of-reservation-amount.backwards.excludes
@@ -1,0 +1,10 @@
+#
+# Package private classes: The following changes don't break the backward compatibility
+#
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("lerna.util.sequence.SequenceFactoryWorker#SequenceContext.freeAmount")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("lerna.util.sequence.SequenceStore#ReserveSequence.reservationAmount")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("lerna.util.sequence.SequenceStore#ReserveSequence.copy")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("lerna.util.sequence.SequenceStore#ReserveSequence.copy$default$2")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("lerna.util.sequence.SequenceStore#ReserveSequence.this")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("lerna.util.sequence.SequenceStore#ReserveSequence.apply")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("lerna.util.sequence.SequenceStore#ReserveSequence.unapply")

--- a/lerna-util-sequence/src/main/scala/lerna/util/sequence/SequenceFactoryWorker.scala
+++ b/lerna-util-sequence/src/main/scala/lerna/util/sequence/SequenceFactoryWorker.scala
@@ -82,13 +82,13 @@ private[sequence] object SequenceFactoryWorker extends AppTypedActorLogging {
       }
 
     /** 追加で予約可能なシーケンスの数 */
-    def freeAmount(implicit config: SequenceConfig): Int =
-      Math.min(
-        // 予約数制限（reservationAmount）の中で採番可能なシーケンスの数
-        (config.reservationAmount - remainAmount).toInt,
+    def freeAmount(implicit config: SequenceConfig): BigInt = {
+      // 予約数制限（reservationAmount）の中で採番可能なシーケンスの数
+      (config.reservationAmount - remainAmount).min(
         // 最大シーケンス番号（maxSequenceValue）までの間で採番可能なシーケンスの数
-        ((config.maxSequenceValue - maxReservedValue) / config.incrementStep).toInt,
+        (config.maxSequenceValue - maxReservedValue) / config.incrementStep,
       )
+    }
 
     /** 発行できるシーケンスの最大値を超えている */
     def isOverflow(implicit config: SequenceConfig): Boolean =
@@ -239,7 +239,7 @@ private[sequence] final class SequenceFactoryWorker(
     }
   }
 
-  private[this] def reserve(sequenceContext: SequenceContext, amount: Int): Unit = {
+  private[this] def reserve(sequenceContext: SequenceContext, amount: BigInt): Unit = {
     logger.info(
       "Reserving sequence: remain {}, add {}, current max reserved: {}",
       sequenceContext.remainAmount,

--- a/lerna-util-sequence/src/main/scala/lerna/util/sequence/SequenceStore.scala
+++ b/lerna-util-sequence/src/main/scala/lerna/util/sequence/SequenceStore.scala
@@ -163,7 +163,7 @@ private[sequence] object SequenceStore extends AppTypedActorLogging {
   }
   final case class ReserveSequence(
       maxReservedValue: BigInt,
-      reservationAmount: Int,
+      reservationAmount: BigInt,
       sequenceSubId: Option[String],
       replyTo: ActorRef[ReservationResponse],
   ) extends Command {

--- a/lerna-util-sequence/src/test/scala/lerna/util/sequence/CassandraSequenceFactorySpec.scala
+++ b/lerna-util-sequence/src/test/scala/lerna/util/sequence/CassandraSequenceFactorySpec.scala
@@ -163,8 +163,8 @@ class CassandraSequenceFactorySpec
       val incrementStep     = config.getInt("lerna.util.sequence.max-node-id")
       val sequenceCacheSize = 11
       val maxReservedValue  = initialValue + (incrementStep * (sequenceCacheSize - 1))
-      // freeAmountの計算で利用する `最大シーケンス番号までの間で採番可能なシーケンス数` がInt型の最大値を超えるようにmaxSequenceを設定
-      val maxSequence = (BigInt(Int.MaxValue) + 1) * config.getInt("lerna.util.sequence.max-node-id") + maxReservedValue
+      // freeAmountの計算で利用する `最大シーケンス番号までの間で採番可能なシーケンス数` がLong型の最大値を超えるようにmaxSequenceを設定
+      val maxSequence = (BigInt(Long.MaxValue) + 1) * config.getInt("lerna.util.sequence.max-node-id") + maxReservedValue
 
       val sequenceFactory: SequenceFactory = new TestSequenceFactory(
         seqId = UUID.randomUUID().toString,

--- a/lerna-util-sequence/src/test/scala/lerna/util/sequence/CassandraSequenceFactorySpec.scala
+++ b/lerna-util-sequence/src/test/scala/lerna/util/sequence/CassandraSequenceFactorySpec.scala
@@ -164,7 +164,8 @@ class CassandraSequenceFactorySpec
       val sequenceCacheSize = 11
       val maxReservedValue  = initialValue + (incrementStep * (sequenceCacheSize - 1))
       // freeAmountの計算で利用する `最大シーケンス番号までの間で採番可能なシーケンス数` がLong型の最大値を超えるようにmaxSequenceを設定
-      val maxSequence = (BigInt(Long.MaxValue) + 1) * config.getInt("lerna.util.sequence.max-node-id") + maxReservedValue
+      val maxSequence =
+        (BigInt(Long.MaxValue) + 1) * config.getInt("lerna.util.sequence.max-node-id") + maxReservedValue
 
       val sequenceFactory: SequenceFactory = new TestSequenceFactory(
         seqId = UUID.randomUUID().toString,

--- a/lerna-util-sequence/src/test/scala/lerna/util/sequence/CassandraSequenceFactorySpec.scala
+++ b/lerna-util-sequence/src/test/scala/lerna/util/sequence/CassandraSequenceFactorySpec.scala
@@ -156,6 +156,30 @@ class CassandraSequenceFactorySpec
       }
     }
 
+    "maxSequenceValueが非常に大きい値の場合に`freeAmount`の計算結果がオーバーフローを発生しない" in {
+      implicit val config: Config = baseConfig
+
+      val initialValue      = config.getInt("lerna.util.sequence.node-id")
+      val incrementStep     = config.getInt("lerna.util.sequence.max-node-id")
+      val sequenceCacheSize = 11
+      val maxReservedValue  = initialValue + (incrementStep * (sequenceCacheSize - 1))
+      // freeAmountの計算で利用する `最大シーケンス番号までの間で採番可能なシーケンス数` がInt型の最大値を超えるようにmaxSequenceを設定
+      val maxSequence = (BigInt(Int.MaxValue) + 1) * config.getInt("lerna.util.sequence.max-node-id") + maxReservedValue
+
+      val sequenceFactory: SequenceFactory = new TestSequenceFactory(
+        seqId = UUID.randomUUID().toString,
+        maxSequence,
+        sequenceCacheSize,
+      )
+
+      // maxReservedValue が更新されるまで採番要求をおこなう
+      val sequence: Future[List[BigInt]] = Future.traverse((1 to 12).toList) { _ => sequenceFactory.nextId() }
+
+      whenReady(sequence) { seq =>
+        expect(seq === List(1, 10, 19, 28, 37, 46, 55, 64, 73, 82, 91, 100).map(BigInt(_)))
+      }
+    }
+
     "対応テナントではない場合Future.failedになる" in {
 
       implicit val config: Config = baseConfig

--- a/lerna-util-sequence/src/test/scala/lerna/util/sequence/SequenceFactoryWorkerSpec.scala
+++ b/lerna-util-sequence/src/test/scala/lerna/util/sequence/SequenceFactoryWorkerSpec.scala
@@ -101,7 +101,7 @@ class SequenceFactoryWorkerSpec
       inside(storeProbe.receiveMessage()) {
         case result: SequenceStore.ReserveSequence =>
           expect(result.maxReservedValue === BigInt(13))
-          expect(result.reservationAmount === 1) // 設定された reservationAmount - 消費済みの採番数
+          expect(result.reservationAmount === BigInt(1)) // 設定された reservationAmount - 消費済みの採番数
           expect(result.sequenceSubId === sequenceSubId)
           result.replyTo ! SequenceStore.SequenceReserved(
             maxReservedValue = BigInt(23), // maxReservedValue + (incrementStep * reservationAmount)
@@ -162,7 +162,7 @@ class SequenceFactoryWorkerSpec
       inside(storeProbe.receiveMessage()) {
         case result: SequenceStore.ReserveSequence =>
           expect(result.maxReservedValue === BigInt(13))
-          expect(result.reservationAmount === 2)
+          expect(result.reservationAmount === BigInt(2))
           expect(result.sequenceSubId === sequenceSubId)
           result.replyTo ! SequenceStore.SequenceReserved(
             maxReservedValue = BigInt(33), // maxReservedValue + (incrementStep * (reservationAmount - 消費済みの採番数))
@@ -211,7 +211,7 @@ class SequenceFactoryWorkerSpec
       val replyTo2 = inside(storeProbe.receiveMessage()) {
         case result: SequenceStore.ReserveSequence =>
           expect(result.maxReservedValue === BigInt(3))
-          expect(result.reservationAmount === 1)
+          expect(result.reservationAmount === BigInt(1))
           expect(result.sequenceSubId === sequenceSubId)
           result.replyTo
       }
@@ -407,7 +407,7 @@ class SequenceFactoryWorkerSpec
       inside(storeProbe.receiveMessage()) {
         case reserve: SequenceStore.ReserveSequence =>
           expect(reserve.maxReservedValue === BigInt(firstValue)) // 3
-          expect(reserve.reservationAmount === reservationAmount)
+          expect(reserve.reservationAmount === BigInt(reservationAmount))
           expect(reserve.sequenceSubId === sequenceSubId)
           reserve.replyTo ! SequenceStore.SequenceReserved(maxReservedValue =
             reserve.maxReservedValue + (incrementStep * reserve.reservationAmount),


### PR DESCRIPTION
#88 

- maxSequenceの値が非常に大きい値の場合に、`freeAmount`の計算でオーバーフローが発生し採番が失敗するテストを追加
- `freeAmount`関数の型を`BigInt`に変更し、大きい値の計算時にオーバーフローが発生しないように修正