### PR TITLE
ReadTimeoutException等発生後も新規採番予約を処理するように SequenceStore を修正する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 [Unreleased]: https://github.com/lerna-stack/lerna-app-library/compare/v3.0.2...main
 
+### Fixed
+- `lerna-util-sequence`
+  - SequenceStore couldn't process new sequence reservations after it recovered from a ReadTimeException, etc.
+    [#91](https://github.com/lerna-stack/lerna-app-library/issues/91),
+    [PR#92](https://github.com/lerna-stack/lerna-app-library/pull/92)
+
 ## [v3.0.2] - 2023-06-19
 [v3.0.2]: https://github.com/lerna-stack/lerna-app-library/compare/v3.0.1...v3.0.2
 

--- a/lerna-util-sequence/src/main/scala/lerna/util/sequence/CqlStatementExecutor.scala
+++ b/lerna-util-sequence/src/main/scala/lerna/util/sequence/CqlStatementExecutor.scala
@@ -1,0 +1,33 @@
+package lerna.util.sequence
+
+import com.datastax.oss.driver.api.core.CqlSession
+import com.datastax.oss.driver.api.core.cql.{ AsyncResultSet, PreparedStatement, SimpleStatement, Statement }
+
+import scala.compat.java8.FutureConverters.CompletionStageOps
+import scala.concurrent.Future
+
+/** Prepares and executes CQL statements.
+  *
+  * It is helpful for tests, for example, mocking or stubbing a CQL statement execution.
+  * It delegates actual tasks to [[com.datastax.oss.driver.api.core.CqlSession]].
+  */
+private[sequence] trait CqlStatementExecutor {
+
+  /** Executes a CQL statement asynchronously */
+  def executeAsync[T <: Statement[T]](
+      statement: Statement[T],
+  )(implicit session: CqlSession): Future[AsyncResultSet] = {
+    session.executeAsync(statement).toScala
+  }
+
+  /** Prepares a CQL statement asynchronously */
+  def prepareAsync(
+      statement: SimpleStatement,
+  )(implicit session: CqlSession): Future[PreparedStatement] = {
+    session.prepareAsync(statement).toScala
+  }
+
+}
+
+/** The default instance of [[CqlStatementExecutor]]. */
+private[sequence] object CqlStatementExecutor extends CqlStatementExecutor

--- a/lerna-util-sequence/src/main/scala/lerna/util/sequence/SequenceStore.scala
+++ b/lerna-util-sequence/src/main/scala/lerna/util/sequence/SequenceStore.scala
@@ -44,7 +44,7 @@ private[sequence] object SequenceStore extends AppTypedActorLogging {
         }
       }
     }
-    Behaviors.supervise(behavior).onFailure[Exception](SupervisorStrategy.restart)
+    Behaviors.supervise(behavior).onFailure(SupervisorStrategy.restart)
   }
 
   sealed trait Command            extends NoSerializationVerificationNeeded

--- a/lerna-util-sequence/src/main/scala/lerna/util/sequence/SequenceStore.scala
+++ b/lerna-util-sequence/src/main/scala/lerna/util/sequence/SequenceStore.scala
@@ -27,8 +27,7 @@ private[sequence] object SequenceStore extends AppTypedActorLogging {
   )(implicit
       tenant: Tenant,
   ): Behavior[Command] = {
-    @SuppressWarnings(Array("org.wartremover.warts.Var"))
-    var behavior: Behavior[Command] = Behaviors.setup { context =>
+    val behavior: Behavior[Command] = Behaviors.setup { context =>
       val capacity = context.system.settings.config.getInt("lerna.util.sequence.store.stash-capacity")
       Behaviors.withStash(capacity) { buffer =>
         withLogger { logger =>
@@ -45,116 +44,7 @@ private[sequence] object SequenceStore extends AppTypedActorLogging {
         }
       }
     }
-
-    //
-    // SupervisorStrategy
-    // 基本方針として、Cassandra に再接続しなくても回復できそうな例外は  resume する。
-    // それ以外の例外は、Cassandra に再接続するため restart する。
-    //
-    // 発生しうる例外は、次のリンクから確認できる。
-    // https://docs.datastax.com/en/developer/java-driver/4.6/manual/core/retries/#retries
-    //
-    // DefaultRetryPolicy は、次のリンクから確認できる。
-    // https://github.com/datastax/java-driver/blob/4.6.0/core/src/main/java/com/datastax/oss/driver/internal/core/retry/DefaultRetryPolicy.java
-    //
-    // 最終的に Exception は restart するため 一部コードは冗長であるが、
-    // エラー発生状況を明示することを目的としてそのまま記載している。
-    //
-
-    // Consistency Level を満たせる十分な Replica が存在しない。
-    // Cassandra クラスタが回復することを期待する。Cassandra に再接続しなくてもよい。
-    //
-    // https://docs.datastax.com/en/developer/java-driver/4.6/manual/core/retries/#on-unavailable
-    // https://docs.datastax.com/en/drivers/java/4.6/com/datastax/oss/driver/api/core/servererrors/UnavailableException.html
-    //
-    behavior = Behaviors.supervise(behavior).onFailure[UnavailableException](SupervisorStrategy.resume)
-
-    // 一時的にレプリカが処理できなくなっている。
-    // Cassandra サイドで回復することを期待する。Cassandra に再接続しなくてもよい。
-    //
-    // https://docs.datastax.com/en/developer/java-driver/4.6/manual/core/retries/#on-read-timeout
-    // https://docs.datastax.com/en/drivers/java/4.6/com/datastax/oss/driver/api/core/servererrors/ReadTimeoutException.html
-    //
-    behavior = Behaviors.supervise(behavior).onFailure[ReadTimeoutException](SupervisorStrategy.resume)
-
-    // 一時的にレプリカが処理できなくなっている。
-    // Cassandra サイドで回復することを期待する。Cassandra に再接続しなくてもよい。
-    //
-    // https://docs.datastax.com/en/developer/java-driver/4.6/manual/core/retries/#on-write-timeout
-    // https://docs.datastax.com/en/drivers/java/4.6/com/datastax/oss/driver/api/core/servererrors/WriteTimeoutException.html
-    //
-    behavior = Behaviors.supervise(behavior).onFailure[WriteTimeoutException](SupervisorStrategy.resume)
-
-    // https://docs.datastax.com/en/developer/java-driver/4.6/manual/core/retries/#on-request-aborted
-    //
-    // - https://docs.datastax.com/en/drivers/java/4.6/com/datastax/oss/driver/api/core/connection/ClosedConnectionException.html
-    // - https://docs.datastax.com/en/drivers/java/4.6/com/datastax/oss/driver/api/core/connection/HeartbeatException.html
-    //
-    // クエリが冪等である場合、ドライバの RetryPolicy によって処理される。
-    // DefaultRetryPolicy を使っている場合は、ドライバにて次ノードにリトライする。
-    // すべてのノードが応答しない場合、AllNodesFailedException が発生する。
-    // (AllNodeFailedExceptionは、このメソッドの下部で処理する)
-    //
-    // クエリが冪等でない場合、RetryPolicyはバイパスされ、これらの例外が発生する。
-    //
-    // これらの例外は再接続する方が恐らく安全である。
-    //
-    behavior = Behaviors.supervise(behavior).onFailure[ClosedConnectionException](SupervisorStrategy.restart)
-    behavior = Behaviors.supervise(behavior).onFailure[HeartbeatException](SupervisorStrategy.restart)
-
-    // https://docs.datastax.com/en/developer/java-driver/4.6/manual/core/retries/#on-error-response
-    //
-    //  - https://docs.datastax.com/en/drivers/java/4.6/com/datastax/oss/driver/api/core/servererrors/OverloadedException.html
-    //  - https://docs.datastax.com/en/drivers/java/4.6/com/datastax/oss/driver/api/core/servererrors/ServerError.html
-    //  - https://docs.datastax.com/en/drivers/java/4.6/com/datastax/oss/driver/api/core/servererrors/TruncateException.html
-    //
-    // クエリが冪等である場合、ドライバの RetryPolicy によって処理される。
-    // DefaultRetryPolicy を使っている場合は、ドライバにて次ノードにリトライする。
-    // すべてのノードが応答しない場合、AllNodesFailedException が発生する。
-    // (AllNodeFailedExceptionは、このメソッドの下部で処理する)
-    //
-    // クエリが冪等でない場合、RetryPolicyはバイパスされ、これらの例外が発生する。
-    //
-    // Coordinator とは通信できているため、恐らく Cassandra に再接続する必要はない。
-    // ただし、過負荷やサーバでエラーが発生している状況のため、より安全な方法をとった方がよい。
-    //
-    behavior = Behaviors.supervise(behavior).onFailure[OverloadedException](SupervisorStrategy.restart)
-    behavior = Behaviors.supervise(behavior).onFailure[ServerError](SupervisorStrategy.restart)
-    behavior = Behaviors.supervise(behavior).onFailure[TruncateException](SupervisorStrategy.restart)
-
-    // https://docs.datastax.com/en/developer/java-driver/4.6/manual/core/retries/#on-error-response
-    //
-    //  - https://docs.datastax.com/en/drivers/java/4.6/com/datastax/oss/driver/api/core/servererrors/ReadFailureException.html
-    //  - https://docs.datastax.com/en/drivers/java/4.6/com/datastax/oss/driver/api/core/servererrors/WriteFailureException.html
-    //
-    // クエリが冪等である場合、ドライバの RetryPolicy によって処理される。
-    // DefaultRetryPolicy を使っている場合は、これらの例外が発生する。クエリが冪等でない場合も、これらの例外が発生する。
-    // 他の RetryPolicy を使用した場合は、その実装に依存した例外が発生する可能性があるため注意すること。
-    //
-    // 一部 Replica がエラーを返しているような場合に発生することがある。
-    // Coordinator とは通信できているため、Cassandra に再接続する必要はない。
-    //
-    behavior = Behaviors.supervise(behavior).onFailure[ReadFailureException](SupervisorStrategy.resume)
-    behavior = Behaviors.supervise(behavior).onFailure[WriteFailureException](SupervisorStrategy.resume)
-
-    // すべての Coordinator に対してクエリが失敗した。
-    // 自身が孤立しているか、Cassandra に災害 が発生している可能性がある。
-    // https://docs.datastax.com/en/drivers/java/4.6/com/datastax/oss/driver/api/core/AllNodesFailedException.html
-    //
-    behavior = Behaviors.supervise(behavior).onFailure[AllNodesFailedException](SupervisorStrategy.restart)
-
-    // ドライバでタイムアウトが発生した。
-    // Coordinator が全く反応していない場合に発生する。
-    // https://docs.datastax.com/en/drivers/java/4.6/com/datastax/oss/driver/api/core/DriverTimeoutException.html
-    //
-    behavior = Behaviors.supervise(behavior).onFailure[DriverTimeoutException](SupervisorStrategy.restart)
-
-    //
-    // その他の例外は restart して Cassandra に再接続することで、回復することを期待する
-    //
-    behavior = Behaviors.supervise(behavior).onFailure[Exception](SupervisorStrategy.restart)
-
-    behavior
+    Behaviors.supervise(behavior).onFailure[Exception](SupervisorStrategy.restart)
   }
 
   sealed trait Command            extends NoSerializationVerificationNeeded
@@ -215,6 +105,82 @@ private[sequence] object SequenceStore extends AppTypedActorLogging {
       selectSequenceReservationStatement: PreparedStatement,
       insertSequenceReservationStatement: PreparedStatement,
   )
+
+  /** Returns true if a SequenceStore should restart to recover from the given exception. */
+  def shouldRestartToRecoverFrom(exception: Throwable): Boolean = {
+    // 基本方針として、Cassandra に再接続しなくても回復できるだろう例外は自身を再起動しない。
+    // それ以外の例外は、Cassandra に再接続するために自身を再起動する。
+    //
+    // 発生しうる例外は次のリンクから確認できる:
+    // https://docs.datastax.com/en/developer/java-driver/4.6/manual/core/retries/#retries
+    //
+    // DefaultRetryPolicy は次のリンクから確認できる:
+    // https://github.com/datastax/java-driver/blob/4.6.0/core/src/main/java/com/datastax/oss/driver/internal/core/retry/DefaultRetryPolicy.java
+    //
+    // 例外発生状況を明示することを目的として、一部コードは冗長な記載である:
+    //
+    exception match {
+      case _: UnavailableException =>
+        // Consistency Level を満たせる十分な Replica が存在しなかった。
+        // Cassandra クラスタが回復することを期待する。Cassandra に再接続しなくてよい。
+        // - https://docs.datastax.com/en/developer/java-driver/4.6/manual/core/retries/#on-unavailable
+        // - https://docs.datastax.com/en/drivers/java/4.6/com/datastax/oss/driver/api/core/servererrors/UnavailableException.html
+        false
+      case _: ReadTimeoutException =>
+        // レプリカが読み込みリクエストに時間内に応答しなかった。
+        // Cassandra クラスタが回復することを期待する。Cassandra に再接続しなくてよい。
+        // - https://docs.datastax.com/en/developer/java-driver/4.6/manual/core/retries/#on-read-timeout
+        // - https://docs.datastax.com/en/drivers/java/4.6/com/datastax/oss/driver/api/core/servererrors/ReadTimeoutException.html
+        false
+      case _: WriteTimeoutException =>
+        // レプリカが書き込みリクエストに時間内に応答しなかった。
+        // Cassandra クラスタが回復することを期待する。Cassandra に再接続しなくてよい。
+        // - https://docs.datastax.com/en/developer/java-driver/4.6/manual/core/retries/#on-write-timeout
+        // - https://docs.datastax.com/en/drivers/java/4.6/com/datastax/oss/driver/api/core/servererrors/WriteTimeoutException.html
+        false
+      case _: ClosedConnectionException | _: HeartbeatException =>
+        // ClosedConnectionException: コネクションが外部要因で閉じられた。
+        // HeartbeatException: ハートビートクエリに失敗した。
+        // 安全のため再起動する。
+        // - https://docs.datastax.com/en/developer/java-driver/4.6/manual/core/retries/#on-request-aborted
+        // - https://docs.datastax.com/en/drivers/java/4.6/com/datastax/oss/driver/api/core/connection/ClosedConnectionException.html
+        // - https://docs.datastax.com/en/drivers/java/4.6/com/datastax/oss/driver/api/core/connection/HeartbeatException.html
+        true
+      case _: OverloadedException | _: ServerError | _: TruncateException =>
+        // OverloadedException: コーディネータが過負荷であった。
+        // ServerError: サーバが内部エラーを報告した。
+        // TruncateException: truncate 操作でエラーが発生した。
+        // 安全のため再起動する。
+        // - https://docs.datastax.com/en/developer/java-driver/4.6/manual/core/retries/#on-error-response
+        // - https://docs.datastax.com/en/drivers/java/4.6/com/datastax/oss/driver/api/core/servererrors/OverloadedException.html
+        // - https://docs.datastax.com/en/drivers/java/4.6/com/datastax/oss/driver/api/core/servererrors/ServerError.html
+        // - https://docs.datastax.com/en/drivers/java/4.6/com/datastax/oss/driver/api/core/servererrors/TruncateException.html
+        true
+      case _: ReadFailureException | _: WriteFailureException =>
+        // ReadFailureException: レプリカが読み込みリクエストにタイムアウト以外のエラーを応答した。
+        // WriteFailureException: レプリカが書き込みリクエストにタイムアウト以外のエラーを応答した。
+        // Cassandra クラスタが回復することを期待する。Cassandra に再接続しなくてよい。
+        // - https://docs.datastax.com/en/developer/java-driver/4.6/manual/core/retries/#on-error-response
+        // - https://docs.datastax.com/en/drivers/java/4.6/com/datastax/oss/driver/api/core/servererrors/ReadFailureException.html
+        // - https://docs.datastax.com/en/drivers/java/4.6/com/datastax/oss/driver/api/core/servererrors/WriteFailureException.html
+        false
+      case _: AllNodesFailedException =>
+        // すべてのコーディネータに対してクエリが失敗した。
+        // 自身が孤立しているか、Cassandra で災害が発生している可能性がある。
+        // 安全のため再起動する。
+        // https://docs.datastax.com/en/drivers/java/4.6/com/datastax/oss/driver/api/core/AllNodesFailedException.html
+        true
+      case _: DriverTimeoutException =>
+        // ドライバ要求でタイムアウトが発生した。
+        // https://docs.datastax.com/en/drivers/java/4.6/com/datastax/oss/driver/api/core/DriverTimeoutException.html
+        // 安全のため再起動する。
+        true
+      case _ =>
+        // その他の例外は再起動して回復することを期待する。
+        true
+    }
+  }
+
 }
 
 private[sequence] final class SequenceStore(
@@ -272,8 +238,9 @@ private[sequence] final class SequenceStore(
     case SessionPrepared(sessionContext) =>
       logger.info("Cassandra session was ready (sequenceId: {}, nodeId: {})", sequenceId, nodeId)
       stashBuffer.unstashAll(ready(sessionContext))
-
-    case SessionFailed(throwable)     => throw throwable
+    case SessionFailed(throwable) =>
+      // TODO 一部の例外は再起動せずに処理を再試行する
+      throw throwable // to restart
     case _: InternalReservationResult => Behaviors.unhandled
   }
 
@@ -303,6 +270,7 @@ private[sequence] final class SequenceStore(
       case _: InternalReservationResult => Behaviors.unhandled
     }.receiveSignal(close(sessionContext.session))
 
+  @SuppressWarnings(Array("lerna.warts.CyclomaticComplexity"))
   private[this] def reserving(replyTo: ActorRef[ReservationResponse])(implicit sessionContext: SessionContext) =
     Behaviors
       .receiveMessage[Command] {
@@ -326,7 +294,19 @@ private[sequence] final class SequenceStore(
           stashBuffer.unstashAll(ready)
         case InternalReservationFailed(exception) =>
           replyTo ! ReservationFailed
-          throw exception
+          if (shouldRestartToRecoverFrom(exception)) {
+            throw exception // to restart
+          } else {
+            // TODO 失敗した処理の情報(initialReserve,reserve,rest)を出力する
+            logger.info(
+              "sequenceId=[{}], nodeId=[{}]: Recovering from InternalReservationFailed: [{}: {}]",
+              sequenceId,
+              nodeId,
+              exception.getClass.getCanonicalName,
+              exception.getMessage,
+            )
+            stashBuffer.unstashAll(ready)
+          }
         case OpenSession      => Behaviors.unhandled
         case _: SessionResult => Behaviors.unhandled
       }.receiveSignal(close(sessionContext.session))

--- a/lerna-util-sequence/src/test/scala/lerna/util/sequence/SequenceStoreSpec.scala
+++ b/lerna-util-sequence/src/test/scala/lerna/util/sequence/SequenceStoreSpec.scala
@@ -89,7 +89,7 @@ class SequenceStoreSpec extends ScalaTestWithTypedActorTestKit(SequenceStoreSpec
   trait CqlStatementExecutorStubFixture {
     private val executeAsyncFailureRef = new AtomicReference[Option[Throwable]](None)
 
-    val executor: CqlStatementExecutor = new CqlStatementExecutor {
+    val executorStub: CqlStatementExecutor = new CqlStatementExecutor {
       override def executeAsync[T <: Statement[T]](
           statement: Statement[T],
       )(implicit session: CqlSession): Future[AsyncResultSet] = {
@@ -258,7 +258,7 @@ class SequenceStoreSpec extends ScalaTestWithTypedActorTestKit(SequenceStoreSpec
       // SequenceStore は継続不可能な例外によってセッション準備に失敗する:
       failNextExecuteAsync(new RuntimeException("expected exception for test"))
 
-      val store = spawnSequenceStore(nodeId = 1, incrementStep = 3, executor = executor)
+      val store = spawnSequenceStore(nodeId = 1, incrementStep = 3, executor = executorStub)
 
       // SequenceStore は、再起動した後、次の採番予約を処理する:
       eventually {
@@ -283,7 +283,7 @@ class SequenceStoreSpec extends ScalaTestWithTypedActorTestKit(SequenceStoreSpec
         failNextExecuteAsync(new ReadTimeoutException(node, ConsistencyLevel.LOCAL_QUORUM, 1, 2, false))
       }
 
-      val store = spawnSequenceStore(nodeId = 1, incrementStep = 3, executor = executor)
+      val store = spawnSequenceStore(nodeId = 1, incrementStep = 3, executor = executorStub)
 
       // SequenceStore は、次の採番予約を処理する:
       eventually {
@@ -302,7 +302,7 @@ class SequenceStoreSpec extends ScalaTestWithTypedActorTestKit(SequenceStoreSpec
     }
 
     "継続不可能な例外によって初期採番予約に失敗した後、次の初期採番予約を処理する" in new Fixture with CqlStatementExecutorStubFixture {
-      val store = spawnSequenceStore(nodeId = 1, incrementStep = 3, executor = executor)
+      val store = spawnSequenceStore(nodeId = 1, incrementStep = 3, executor = executorStub)
 
       // SequenceStore が ready になっていることを確認するため:
       store ! SequenceStore.InitialReserveSequence(
@@ -342,7 +342,7 @@ class SequenceStoreSpec extends ScalaTestWithTypedActorTestKit(SequenceStoreSpec
     }
 
     "継続可能な例外によって初期採番予約に失敗した後、次の初期採番予約を処理する" in new Fixture with CqlStatementExecutorStubFixture {
-      val store = spawnSequenceStore(nodeId = 1, incrementStep = 3, executor = executor)
+      val store = spawnSequenceStore(nodeId = 1, incrementStep = 3, executor = executorStub)
 
       // SequenceStore が ready になっていることを確認するため:
       store ! SequenceStore.InitialReserveSequence(
@@ -383,7 +383,7 @@ class SequenceStoreSpec extends ScalaTestWithTypedActorTestKit(SequenceStoreSpec
     }
 
     "継続不可能な例外によって採番予約に失敗した後、次の採番予約を処理する" in new Fixture with CqlStatementExecutorStubFixture {
-      val store = spawnSequenceStore(nodeId = 1, incrementStep = 3, executor = executor)
+      val store = spawnSequenceStore(nodeId = 1, incrementStep = 3, executor = executorStub)
 
       store ! SequenceStore.InitialReserveSequence(
         firstValue = 1,
@@ -420,7 +420,7 @@ class SequenceStoreSpec extends ScalaTestWithTypedActorTestKit(SequenceStoreSpec
     }
 
     "継続可能な例外によって採番予約に失敗した後、次の採番予約を処理する" in new Fixture with CqlStatementExecutorStubFixture {
-      val store = spawnSequenceStore(nodeId = 1, incrementStep = 3, executor = executor)
+      val store = spawnSequenceStore(nodeId = 1, incrementStep = 3, executor = executorStub)
 
       store ! SequenceStore.InitialReserveSequence(
         firstValue = 1,
@@ -458,7 +458,7 @@ class SequenceStoreSpec extends ScalaTestWithTypedActorTestKit(SequenceStoreSpec
     }
 
     "継続不可能な例外によって採番リセットに失敗した後、次の採番リセットを処理する" in new Fixture with CqlStatementExecutorStubFixture {
-      val store = spawnSequenceStore(nodeId = 1, incrementStep = 3, executor = executor)
+      val store = spawnSequenceStore(nodeId = 1, incrementStep = 3, executor = executorStub)
 
       store ! SequenceStore.InitialReserveSequence(
         firstValue = 1,
@@ -495,7 +495,7 @@ class SequenceStoreSpec extends ScalaTestWithTypedActorTestKit(SequenceStoreSpec
     }
 
     "継続可能な例外によって採番リセットに失敗した後、次の採番リセットを処理する" in new Fixture with CqlStatementExecutorStubFixture {
-      val store = spawnSequenceStore(nodeId = 1, incrementStep = 3, executor = executor)
+      val store = spawnSequenceStore(nodeId = 1, incrementStep = 3, executor = executorStub)
 
       store ! SequenceStore.InitialReserveSequence(
         firstValue = 1,

--- a/lerna-util-sequence/src/test/scala/lerna/util/sequence/SequenceStoreSpec.scala
+++ b/lerna-util-sequence/src/test/scala/lerna/util/sequence/SequenceStoreSpec.scala
@@ -319,6 +319,107 @@ class SequenceStoreSpec extends ScalaTestWithTypedActorTestKit(SequenceStoreSpec
       testKit.stop(store)
     }
 
+    "継続不可能な例外によって初期採番予約に失敗した後、次の初期採番予約を処理する" in new CqlStatementExecutorStubFixture {
+      val testProbe = createTestProbe[SequenceStore.ReservationResponse]()
+
+      val store = spawn(
+        SequenceStore(
+          sequenceId = generateUniqueId(),
+          nodeId = 1,
+          incrementStep = 3,
+          config = cassandraConfig,
+          executor = executor,
+        ),
+      )
+
+      // SequenceStore が ready になっていることを確認するため:
+      store ! SequenceStore.InitialReserveSequence(
+        firstValue = 1,
+        reservationAmount = 101,
+        sequenceSubId,
+        testProbe.ref,
+      )
+      testProbe.expectMessage(
+        SequenceStore.InitialSequenceReserved(initialValue = 1, maxReservedValue = 301),
+      )
+
+      // SequenceStore は継続不可能な例外によって初期採番予約に失敗する:
+      failNextExecuteAsync(new RuntimeException("expected exception for test"))
+      store ! SequenceStore.InitialReserveSequence(
+        firstValue = 1,
+        reservationAmount = 101,
+        sequenceSubId,
+        testProbe.ref,
+      )
+      testProbe.expectMessage(SequenceStore.ReservationFailed)
+
+      // SequenceStore は、再起動した後、次の初期採番予約を処理する:
+      eventually {
+        store ! SequenceStore.InitialReserveSequence(
+          firstValue = 1,
+          reservationAmount = 101,
+          sequenceSubId,
+          testProbe.ref,
+        )
+        testProbe.expectMessage(
+          SequenceStore.InitialSequenceReserved(initialValue = 304, maxReservedValue = 604),
+        )
+      }
+
+      testKit.stop(store)
+    }
+
+    "継続可能な例外によって初期採番予約に失敗した後、次の初期採番予約を処理する" in new CqlStatementExecutorStubFixture {
+      val testProbe = createTestProbe[SequenceStore.ReservationResponse]()
+
+      val store = spawn(
+        SequenceStore(
+          sequenceId = generateUniqueId(),
+          nodeId = 1,
+          incrementStep = 3,
+          config = cassandraConfig,
+          executor = executor,
+        ),
+      )
+
+      // SequenceStore が ready になっていることを確認するため:
+      store ! SequenceStore.InitialReserveSequence(
+        firstValue = 1,
+        reservationAmount = 101,
+        sequenceSubId,
+        testProbe.ref,
+      )
+      testProbe.expectMessage(
+        SequenceStore.InitialSequenceReserved(initialValue = 1, maxReservedValue = 301),
+      )
+
+      // SequenceStore は継続可能な例外によって初期採番予約に失敗する:
+      locally {
+        val node = session.execute("SELECT uuid() FROM system.local;").getExecutionInfo.getCoordinator
+        failNextExecuteAsync(new ReadTimeoutException(node, ConsistencyLevel.LOCAL_QUORUM, 1, 2, false))
+      }
+      store ! SequenceStore.InitialReserveSequence(
+        firstValue = 1,
+        reservationAmount = 101,
+        sequenceSubId,
+        testProbe.ref,
+      )
+      testProbe.expectMessage(SequenceStore.ReservationFailed)
+
+      // SequenceStore は、次の初期採番予約を処理する:
+      store ! SequenceStore.InitialReserveSequence(
+        firstValue = 1,
+        reservationAmount = 101,
+        sequenceSubId,
+        testProbe.ref,
+      )
+      testProbe.expectMessage(
+        SequenceStore.InitialSequenceReserved(initialValue = 304, maxReservedValue = 604),
+      )
+
+      testKit.stop(store)
+    }
+
     "継続不可能な例外によって採番予約に失敗した後、次の採番予約を処理する" in new CqlStatementExecutorStubFixture {
       val testProbe = createTestProbe[SequenceStore.ReservationResponse]()
 

--- a/lerna-util-sequence/src/test/scala/lerna/util/sequence/SequenceStoreSpec.scala
+++ b/lerna-util-sequence/src/test/scala/lerna/util/sequence/SequenceStoreSpec.scala
@@ -353,13 +353,15 @@ class SequenceStoreSpec extends ScalaTestWithTypedActorTestKit(SequenceStoreSpec
       testProbe.expectMessage(SequenceStore.ReservationFailed)
 
       // SequenceStore は、再起動した後、次の採番予約を処理する:
-      store ! SequenceStore.ReserveSequence(
-        maxReservedValue = 301,
-        reservationAmount = 100,
-        sequenceSubId,
-        testProbe.ref,
-      )
-      testProbe.expectMessage(SequenceStore.SequenceReserved(maxReservedValue = 601))
+      eventually {
+        store ! SequenceStore.ReserveSequence(
+          maxReservedValue = 301,
+          reservationAmount = 100,
+          sequenceSubId,
+          testProbe.ref,
+        )
+        testProbe.expectMessage(SequenceStore.SequenceReserved(maxReservedValue = 601))
+      }
 
       testKit.stop(store)
     }

--- a/lerna-util-sequence/src/test/scala/lerna/util/sequence/SequenceStoreSpec.scala
+++ b/lerna-util-sequence/src/test/scala/lerna/util/sequence/SequenceStoreSpec.scala
@@ -63,7 +63,7 @@ class SequenceStoreSpec extends ScalaTestWithTypedActorTestKit(SequenceStoreSpec
     finally super.afterAll()
   }
 
-  trait Fixture {
+  private trait Fixture {
     val testProbe: TestProbe[SequenceStore.ReservationResponse] =
       createTestProbe[SequenceStore.ReservationResponse]()
 
@@ -86,7 +86,7 @@ class SequenceStoreSpec extends ScalaTestWithTypedActorTestKit(SequenceStoreSpec
     }
   }
 
-  trait CqlStatementExecutorStubFixture {
+  private trait CqlStatementExecutorStubFixture {
     private val executeAsyncFailureRef = new AtomicReference[Option[Throwable]](None)
 
     val executorStub: CqlStatementExecutor = new CqlStatementExecutor {


### PR DESCRIPTION
closes: https://github.com/lerna-stack/lerna-app-library/issues/91

