### PR TITLE
Lines of Code をカウントする GitHub ワークフローを追加する

### DIFF
--- a/.github/workflows/cloc.yml
+++ b/.github/workflows/cloc.yml
@@ -17,6 +17,7 @@ on:
 jobs:
   cloc:
     runs-on: ubuntu-20.04
+    name: Count Lines of Code
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/cloc.yml
+++ b/.github/workflows/cloc.yml
@@ -42,9 +42,7 @@ jobs:
           fi
           new_tree_ish=$(git rev-parse --abbrev-ref HEAD)
           echo "old_tree_ish=${old_tree_ish} new_tree_ish=${new_tree_ish}"
-          git archive --output "${new_tree_ish}.zip" "${new_tree_ish}"
-          git archive --output "${old_tree_ish}.zip" "${old_tree_ish}"
-          cloc --diff "${old_tree_ish}.zip" "${new_tree_ish}.zip" | tee cloc_diff.txt
+          cloc --git --diff "${old_tree_ish}" "${new_tree_ish}" | tee cloc_diff.txt
         env:
           old_tree_ish: ${{ inputs.old_tree_ish }}
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/cloc.yml
+++ b/.github/workflows/cloc.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Count lines of code
         run: |
           set -eu
-          cloc --exclude-dir=test,target,null . | tee cloc.txt
+          cloc --vcs=git --exclude-dir=test . | tee cloc.txt
       - name: Count diff lines of code
         run: |
           set -eu

--- a/.github/workflows/cloc.yml
+++ b/.github/workflows/cloc.yml
@@ -1,0 +1,56 @@
+# Count Lines of Code
+# https://github.com/AlDanial/cloc
+name: cloc
+
+on:
+  workflow_dispatch:
+    inputs:
+      old_tree_ish:
+        description: "commit-ish git object name"
+        type: string
+        required: false
+  push:
+    branches: [ main, feature/** ]
+  pull_request: # TODO remove me before merge
+    branches: [ main, feature/** ]
+
+jobs:
+  cloc:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install cloc
+        run: sudo apt-get install cloc jq
+      - name: Count lines of code
+        run: |
+          set -eu
+          cloc --exclude-dir=test,target,null . | tee cloc.txt
+      - name: Count diff lines of code
+        run: |
+          set -eu
+          if [ -z "${old_tree_ish}" ]; then
+            old_tree_ish=$(
+              curl -L \
+                -H "Accept: application/vnd.github+json" \
+                -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                https://api.github.com/repos/${{ github.repository }}/releases/latest \
+              | jq -r .tag_name
+            )
+          fi
+          new_tree_ish=$(git rev-parse --abbrev-ref HEAD)
+          echo "old_tree_ish=${old_tree_ish} new_tree_ish=${new_tree_ish}"
+          git archive --output "${new_tree_ish}.zip" "${new_tree_ish}"
+          git archive --output "${old_tree_ish}.zip" "${old_tree_ish}"
+          cloc --diff "${old_tree_ish}.zip" "${new_tree_ish}.zip" | tee cloc_diff.txt
+        env:
+          old_tree_ish: ${{ inputs.old_tree_ish }}
+      - uses: actions/upload-artifact@v3
+        with:
+          name: cloc
+          path: |
+            cloc.txt
+            cloc_diff.txt
+          retention-days: 3

--- a/.github/workflows/cloc.yml
+++ b/.github/workflows/cloc.yml
@@ -11,8 +11,6 @@ on:
         required: false
   push:
     branches: [ main, feature/** ]
-  pull_request: # TODO remove me before merge
-    branches: [ main, feature/** ]
 
 jobs:
   cloc:


### PR DESCRIPTION
Lines of Code をカウントする GitHub ワークフロー `cloc` を追加します。
このワークフローはコードベースの統計を集計するために使用できます。

このワークフローは次の条件で実行されます:
* `main` または `feature/**` ブランチにコミットがプッシュされたとき
* GitHub アクションタブを用いる:
https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow

参考:
* https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#providing-inputs
* https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts
* https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#get-the-latest-release
* https://docs.github.com/en/actions/security-guides/automatic-token-authentication#example-2-calling-the-rest-api