### PR TITLE
lerna-util-sequence のテストを追加する

### DIFF
--- a/lerna-util-sequence/src/main/scala/lerna/util/sequence/CqlSessionProvider.scala
+++ b/lerna-util-sequence/src/main/scala/lerna/util/sequence/CqlSessionProvider.scala
@@ -6,14 +6,21 @@ import com.datastax.oss.driver.api.core.CqlSession
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.{ ExecutionContextExecutor, Future }
 
-private[sequence] object CqlSessionProvider {
+private[sequence] trait CqlSessionProvider {
 
   /** Connect to the Cassandra cluster and returns a [[Future]] instance containing [[CqlSession]].
     *
     * A driver configuration is resolved from the given [[ClassicActorSystemProvider]] and [[SequenceFactoryCassandraConfig]].
     * The connection initialization will be done asynchronously in a driver internal thread pool.
     */
-  def connect(
+  def connect(systemProvider: ClassicActorSystemProvider, config: SequenceFactoryCassandraConfig): Future[CqlSession]
+
+}
+
+private[sequence] object CqlSessionProvider extends CqlSessionProvider {
+
+  /** @inheritdoc */
+  override def connect(
       systemProvider: ClassicActorSystemProvider,
       config: SequenceFactoryCassandraConfig,
   ): Future[CqlSession] = {

--- a/lerna-util-sequence/src/main/scala/lerna/util/sequence/SequenceStore.scala
+++ b/lerna-util-sequence/src/main/scala/lerna/util/sequence/SequenceStore.scala
@@ -23,6 +23,7 @@ private[sequence] object SequenceStore extends AppTypedActorLogging {
       nodeId: Int,
       incrementStep: BigInt,
       config: SequenceFactoryCassandraConfig,
+      cqlSessionProvider: CqlSessionProvider = CqlSessionProvider,
       executor: CqlStatementExecutor = CqlStatementExecutor,
   )(implicit
       tenant: Tenant,
@@ -39,6 +40,7 @@ private[sequence] object SequenceStore extends AppTypedActorLogging {
             context,
             buffer,
             logger,
+            cqlSessionProvider,
             executor,
           ).createBehavior()
         }
@@ -191,6 +193,7 @@ private[sequence] final class SequenceStore(
     context: ActorContext[SequenceStore.Command],
     stashBuffer: StashBuffer[SequenceStore.Command],
     logger: AppLogger,
+    cqlSessionProvider: CqlSessionProvider,
     executor: CqlStatementExecutor,
 )(implicit tenant: Tenant) {
   require(nodeId > 0)
@@ -312,7 +315,7 @@ private[sequence] final class SequenceStore(
       }.receiveSignal(close(sessionContext.session))
 
   private[this] def openSession(): Future[SessionOpened] = {
-    CqlSessionProvider
+    cqlSessionProvider
       .connect(context.system, config)
       .map(SessionOpened.apply)
   }

--- a/lerna-util-sequence/src/test/scala/lerna/util/sequence/SequenceStoreSpec.scala
+++ b/lerna-util-sequence/src/test/scala/lerna/util/sequence/SequenceStoreSpec.scala
@@ -1,5 +1,6 @@
 package lerna.util.sequence
 
+import akka.actor.ClassicActorSystemProvider
 import akka.actor.testkit.typed.scaladsl.TestProbe
 import akka.actor.typed.ActorRef
 import com.datastax.oss.driver.api.core.connection.{ ClosedConnectionException, HeartbeatException }
@@ -82,7 +83,7 @@ class SequenceStoreSpec extends ScalaTestWithTypedActorTestKit(SequenceStoreSpec
         incrementStep: Int,
         executor: CqlStatementExecutor,
     ): ActorRef[SequenceStore.Command] = {
-      spawn(SequenceStore(sequenceId, nodeId, incrementStep, cassandraConfig, executor))
+      spawn(SequenceStore(sequenceId, nodeId, incrementStep, cassandraConfig, executor = executor))
     }
   }
 

--- a/lerna-util-sequence/src/test/scala/lerna/util/sequence/SequenceStoreSpec.scala
+++ b/lerna-util-sequence/src/test/scala/lerna/util/sequence/SequenceStoreSpec.scala
@@ -81,9 +81,37 @@ class SequenceStoreSpec extends ScalaTestWithTypedActorTestKit(SequenceStoreSpec
     def spawnSequenceStore(
         nodeId: Int,
         incrementStep: Int,
+        cqlSessionProvider: CqlSessionProvider,
+    ): ActorRef[SequenceStore.Command] = {
+      spawn(SequenceStore(sequenceId, nodeId, incrementStep, cassandraConfig, cqlSessionProvider = cqlSessionProvider))
+    }
+
+    def spawnSequenceStore(
+        nodeId: Int,
+        incrementStep: Int,
         executor: CqlStatementExecutor,
     ): ActorRef[SequenceStore.Command] = {
       spawn(SequenceStore(sequenceId, nodeId, incrementStep, cassandraConfig, executor = executor))
+    }
+  }
+
+  private trait CqlSessionProviderStubFixture {
+    private val connectFailureRef = new AtomicReference[Option[Throwable]](None)
+
+    val cqlSessionProviderStub: CqlSessionProvider = new CqlSessionProvider {
+      override def connect(
+          systemProvider: ClassicActorSystemProvider,
+          config: SequenceFactoryCassandraConfig,
+      ): Future[CqlSession] = {
+        connectFailureRef.getAndSet(None) match {
+          case Some(cause) => Future.failed(cause)
+          case None        => CqlSessionProvider.connect(systemProvider, config)
+        }
+      }
+    }
+
+    def failNextConnect(cause: Throwable): Unit = {
+      connectFailureRef.set(Option(cause))
     }
   }
 
@@ -253,6 +281,29 @@ class SequenceStoreSpec extends ScalaTestWithTypedActorTestKit(SequenceStoreSpec
       )
 
       testKit.stop(store2)
+    }
+
+    "セッションオープンに失敗した後、次の採番予約を最終的に処理する" in
+    new Fixture with CqlSessionProviderStubFixture {
+      // SequenceStore は例外によってセッションオープンに失敗する:
+      failNextConnect(new RuntimeException("expected exception for test"))
+
+      val store = spawnSequenceStore(nodeId = 1, incrementStep = 3, cqlSessionProvider = cqlSessionProviderStub)
+
+      // SequenceStore は、再起動した後、次の採番予約を処理する:
+      eventually {
+        store ! SequenceStore.InitialReserveSequence(
+          firstValue = 1,
+          reservationAmount = 101,
+          sequenceSubId,
+          testProbe.ref,
+        )
+        testProbe.expectMessage(
+          SequenceStore.InitialSequenceReserved(initialValue = 1, maxReservedValue = 301),
+        )
+      }
+
+      testKit.stop(store)
     }
 
     "継続不可能な例外によってセッション準備に失敗した後、次の採番予約を処理する" in new Fixture with CqlStatementExecutorStubFixture {


### PR DESCRIPTION
lerna-util-sequence に次のテストを追加します:
* SequenceFactoryWorker が一定期間アイドルであった場合に停止すること
* SequenceStore が CqlSession オープンに失敗した場合に、再起動し、最終的に採番予約を処理すること